### PR TITLE
Fixed KeyError bug when using bedpe Hi-C data

### DIFF
--- a/src/predictor.py
+++ b/src/predictor.py
@@ -84,12 +84,21 @@ def add_hic_to_enh_gene_table(enh, genes, pred, hic_file, hic_norm_file, hic_is_
         #Overlap in one direction
         enh_hic1 = df_to_pyranges(enh, start_col = 'enh_midpoint', end_col = 'enh_midpoint', end_slop = 1).join(hic1).df
         genes_hic2 = df_to_pyranges(genes, start_col = 'TargetGeneTSS', end_col = 'TargetGeneTSS', end_slop = 1).join(hic2).df
-        ovl12 = enh_hic1[['enh_idx','hic_idx','hic_contact']].merge(genes_hic2[['gene_idx', 'hic_idx']], on = 'hic_idx')
+
+        if ((len(enh_hic1)) > 0 and (len(genes_hic2) > 0)):
+            ovl12 = enh_hic1[['enh_idx','hic_idx','hic_contact']].merge(genes_hic2[['gene_idx', 'hic_idx']], on = 'hic_idx')
+        else:
+            ovl12 = pd.DataFrame()
 
         #Overlap in the other direction
         enh_hic2 = df_to_pyranges(enh, start_col = 'enh_midpoint', end_col = 'enh_midpoint', end_slop = 1).join(hic2).df
         genes_hic1 = df_to_pyranges(genes, start_col = 'TargetGeneTSS', end_col = 'TargetGeneTSS', end_slop = 1).join(hic1).df
         ovl21 = enh_hic2[['enh_idx','hic_idx','hic_contact']].merge(genes_hic1[['gene_idx', 'hic_idx']], on = ['hic_idx'])
+
+        if ((len(enh_hic2) > 0) and (len(genes_hic1) > 0)):
+            ovl21 = enh_hic2[['enh_idx','hic_idx','hic_contact']].merge(genes_hic1[['gene_idx', 'hic_idx']], on = ['hic_idx'])
+        else:
+            ovl21 = pd.DataFrame()
 
         #Concatenate both directions and merge into preditions
         ovl = pd.concat([ovl12, ovl21]).drop_duplicates()


### PR DESCRIPTION
Dear colleagues!
This is a very small fix for a situation when for a given chromosome no overlap is found in one of the directions (or even both) between bedpe Hi-C data and enhancer or genes coordinates. I think it happened to me because I was using only few manually-specified putative enhancers.
For additional info that's the traceback I was getting:
```
Traceback (most recent call last):
  File "src/predict.py", line 154, in <module>
    main()
  File "src/predict.py", line 110, in main
    this_chr = make_predictions(chromosome, this_enh, this_genes, args)
  File "/opt/ABC-Enhancer-Gene-Prediction/src/predictor.py", line 17, in make_predictions
    pred = add_hic_to_enh_gene_table(enhancers, genes, pred, hic_file, hic_norm_file, hic_is_vc, chromosome, args)
  File "/opt/ABC-Enhancer-Gene-Prediction/src/predictor.py", line 93, in add_hic_to_enh_gene_table
    ovl12 = enh_hic1[['enh_idx','hic_idx','hic_contact']].merge(genes_hic2[['gene_idx', 'hic_idx']], on = 'hic_idx')
  File "/opt/miniconda3/envs/final-abc-env/lib/python3.7/site-packages/pandas/core/frame.py", line 2908, in __getitem__
    indexer = self.loc._get_listlike_indexer(key, axis=1, raise_missing=True)[1]
  File "/opt/miniconda3/envs/final-abc-env/lib/python3.7/site-packages/pandas/core/indexing.py", line 1254, in _get_listlike_indexer
    self._validate_read_indexer(keyarr, indexer, axis, raise_missing=raise_missing)
  File "/opt/miniconda3/envs/final-abc-env/lib/python3.7/site-packages/pandas/core/indexing.py", line 1298, in _validate_read_indexer
    raise KeyError(f"None of [{key}] are in the [{axis_name}]")
KeyError: "None of [Index(['enh_idx', 'hic_idx', 'hic_contact'], dtype='object')] are in the [columns]"
```

Cheers