### PR TITLE
Autoformat all the python files with black

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,14 @@ jobs:
       - checkout
       - run:
           name: Install basic OS pkgs
-          command: apt-get update && apt-get -y install curl vim
+          command: apt-get update && apt-get -y install curl vim black
       - run:
           name: Install abc-env
           command: |
             mamba env create -f workflow/envs/abcenv.yml
+      - run:
+          name: Run Linter (python black)
+          command: black . --check
       - run:
           name: Run tests
           command: |

--- a/tests/test_full_abc_run.py
+++ b/tests/test_full_abc_run.py
@@ -16,30 +16,42 @@ CONFIG_FILE = "tests/config.yaml"
 TEST_OUTPUT_DIR = "tests/test_output"
 EXPECTED_OUTPUT_DIR = "tests/expected_output"
 PREDICTION_FILE = "K562/Predictions/EnhancerPredictionsAllPutative.txt.gz"
-COLUMNS_TO_COMPARE = ['chr', 'start', 'end', 'name', 'class', 'TargetGene', "ABC.Score.Numerator", "ABC.Score"]
-INTERMEDIATE_FILES=[
-    # EnhancerList is not good to compare b/c column names change randomly
-    # "K562/Neighborhoods/EnhancerList.txt", 
-    "K562/Neighborhoods/GeneList.txt", 
-    "K562/Peaks/macs2_peaks.narrowPeak.sorted.candidateRegions.bed"
+COLUMNS_TO_COMPARE = [
+    "chr",
+    "start",
+    "end",
+    "name",
+    "class",
+    "TargetGene",
+    "ABC.Score.Numerator",
+    "ABC.Score",
 ]
+INTERMEDIATE_FILES = [
+    # EnhancerList is not good to compare b/c column names change randomly
+    # "K562/Neighborhoods/EnhancerList.txt",
+    "K562/Neighborhoods/GeneList.txt",
+    "K562/Peaks/macs2_peaks.narrowPeak.sorted.candidateRegions.bed",
+]
+
 
 def read_file(file_name: str) -> List[str]:
     open_fn: Callable = open
     if file_name.endswith(".gz"):
         open_fn = gzip.open
-        
-    with open_fn(file_name, 'r') as f:
+
+    with open_fn(file_name, "r") as f:
         return sorted(f.readlines())
-    
+
 
 def compare_files(test_file: str, expected_file: str) -> bool:
     test_contents = read_file(test_file)
     expected_contents = read_file(expected_file)
     return test_contents == expected_contents
 
+
 def get_filtered_dataframe(file: str) -> pd.DataFrame:
-    return pd.read_csv(file, sep='\t', compression='gzip')[COLUMNS_TO_COMPARE]
+    return pd.read_csv(file, sep="\t", compression="gzip")[COLUMNS_TO_COMPARE]
+
 
 def run_cmd(cmd: str, raise_ex: bool = True) -> bool:
     try:
@@ -51,29 +63,31 @@ def run_cmd(cmd: str, raise_ex: bool = True) -> bool:
         return False
     return True
 
+
 class TestFullABCRun(unittest.TestCase):
     def test_full_abc_run(self):
         start = time.time()
         cmd = f"snakemake -j1 -F --configfile {CONFIG_FILE}"
         run_cmd(cmd)
         time_taken = time.time() - start
-        
-        # compare intermediate files       
+
+        # compare intermediate files
         for file in INTERMEDIATE_FILES:
             test_file = os.path.join(TEST_OUTPUT_DIR, file)
             expected_file = os.path.join(EXPECTED_OUTPUT_DIR, file)
             if not compare_files(test_file, expected_file):
                 logging.error(f"Intermediate file comparison failed for {file}")
-        
+
         test_file = os.path.join(TEST_OUTPUT_DIR, PREDICTION_FILE)
         expected_file = os.path.join(EXPECTED_OUTPUT_DIR, PREDICTION_FILE)
-        pd.testing.assert_frame_equal(get_filtered_dataframe(test_file), get_filtered_dataframe(expected_file))
+        pd.testing.assert_frame_equal(
+            get_filtered_dataframe(test_file), get_filtered_dataframe(expected_file)
+        )
 
         # Make sure the test doesn't take > 3 min
         max_time = 60 * 3  # 3 min
         self.assertLessEqual(time_taken, max_time)
 
-        
-        
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/workflow/scripts/compute_powerlaw_fit_from_hic.py
+++ b/workflow/scripts/compute_powerlaw_fit_from_hic.py
@@ -7,29 +7,62 @@ import glob
 import os
 from hic import *
 
-#To do: 
-#1. Use MLE to estimate exponent?
-#2. Support bedpe
+# To do:
+# 1. Use MLE to estimate exponent?
+# 2. Support bedpe
+
 
 def parseargs():
-    class formatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter):
+    class formatter(
+        argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter
+    ):
         pass
 
-    epilog = ("")
-    parser = argparse.ArgumentParser(description='Helper to compute hic power-law fit parameters',
-                                     epilog=epilog,
-                                     formatter_class=formatter)
-    readable = argparse.FileType('r')
-    parser.add_argument('--hicDir', help="Directory containing observed HiC KR normalized matrices. File naming and structure should be: hicDir/chr*/chr*.KRobserved")
-    parser.add_argument('--outDir', help="Output directory")
-    parser.add_argument('--hic_type', default = 'juicebox', choices=['juicebox','bedpe'], help="format of hic files")
-    parser.add_argument('--resolution', default=5000, type=int, help="For Juicebox: resolution of hic dataset (in bp). For bedpe: distances will be binned to this resolution for powerlaw fit")
-    parser.add_argument('--minWindow', default=5000, type=int, help="Minimum distance between bins to include in powerlaw fit (bp). Recommended to be at least >= resolution to avoid using the diagonal of the HiC Matrix")
-    parser.add_argument('--maxWindow', default=1000000, type=int, help="Maximum distance between bins to include in powerlaw fit (bp)")
-    parser.add_argument('--chr', default='all', help="Comma delimited list of chromosomes to use for fit. Defualts to chr[1..22],chrX")
+    epilog = ""
+    parser = argparse.ArgumentParser(
+        description="Helper to compute hic power-law fit parameters",
+        epilog=epilog,
+        formatter_class=formatter,
+    )
+    readable = argparse.FileType("r")
+    parser.add_argument(
+        "--hicDir",
+        help="Directory containing observed HiC KR normalized matrices. File naming and structure should be: hicDir/chr*/chr*.KRobserved",
+    )
+    parser.add_argument("--outDir", help="Output directory")
+    parser.add_argument(
+        "--hic_type",
+        default="juicebox",
+        choices=["juicebox", "bedpe"],
+        help="format of hic files",
+    )
+    parser.add_argument(
+        "--resolution",
+        default=5000,
+        type=int,
+        help="For Juicebox: resolution of hic dataset (in bp). For bedpe: distances will be binned to this resolution for powerlaw fit",
+    )
+    parser.add_argument(
+        "--minWindow",
+        default=5000,
+        type=int,
+        help="Minimum distance between bins to include in powerlaw fit (bp). Recommended to be at least >= resolution to avoid using the diagonal of the HiC Matrix",
+    )
+    parser.add_argument(
+        "--maxWindow",
+        default=1000000,
+        type=int,
+        help="Maximum distance between bins to include in powerlaw fit (bp)",
+    )
+    parser.add_argument(
+        "--chr",
+        default="all",
+        help="Comma delimited list of chromosomes to use for fit. Defualts to chr[1..22],chrX",
+    )
 
     args = parser.parse_args()
-    return(args)
+    return args
+
 
 def main():
     args = parseargs()
@@ -37,61 +70,97 @@ def main():
 
     HiC = load_hic_for_powerlaw(args)
 
-    #Run 
+    # Run
     slope, intercept, hic_mean_var = do_powerlaw_fit(HiC)
 
-    #print
-    res = pandas.DataFrame({'resolution' : [args.resolution], 'maxWindow' : [args.maxWindow], 'minWindow' : [args.minWindow] ,'pl_gamma' : [slope], 'pl_scale' : [intercept] })
-    res.to_csv(os.path.join(args.outDir, 'hic.powerlaw.txt'), sep='\t', index=False, header=True)
+    # print
+    res = pandas.DataFrame(
+        {
+            "resolution": [args.resolution],
+            "maxWindow": [args.maxWindow],
+            "minWindow": [args.minWindow],
+            "pl_gamma": [slope],
+            "pl_scale": [intercept],
+        }
+    )
+    res.to_csv(
+        os.path.join(args.outDir, "hic.powerlaw.txt"),
+        sep="\t",
+        index=False,
+        header=True,
+    )
 
-    hic_mean_var.to_csv(os.path.join(args.outDir, 'hic.mean_var.txt'), sep='\t', index=True, header=True)
+    hic_mean_var.to_csv(
+        os.path.join(args.outDir, "hic.mean_var.txt"), sep="\t", index=True, header=True
+    )
+
 
 def load_hic_for_powerlaw(args):
-    if args.chr == 'all':
-        chromosomes = ['chr' + str(x) for x in  list(range(1,23))] + ['chrX']
+    if args.chr == "all":
+        chromosomes = ["chr" + str(x) for x in list(range(1, 23))] + ["chrX"]
     else:
-        chromosomes = args.chr.split(',')
+        chromosomes = args.chr.split(",")
 
     all_data_list = []
     for chrom in chromosomes:
         try:
-            if args.hic_type == 'juicebox':
-                hic_file, hic_norm_file, hic_is_vc = get_hic_file(chrom, args.hicDir, allow_vc=False)
+            if args.hic_type == "juicebox":
+                hic_file, hic_norm_file, hic_is_vc = get_hic_file(
+                    chrom, args.hicDir, allow_vc=False
+                )
                 print("Working on {}".format(hic_file))
-                this_data = load_hic(hic_file = hic_file, 
-                    hic_norm_file = hic_norm_file,
-                    hic_is_vc = hic_is_vc, 
-                    hic_type = 'juicebox', 
-                    hic_resolution = args.resolution, 
-                    tss_hic_contribution = 100, 
-                    window = args.maxWindow, 
-                    min_window = args.minWindow, 
-                    gamma = np.nan, 
-                    interpolate_nan=False)
-                this_data['dist_for_fit'] = abs(this_data['bin1'] - this_data['bin2']) * args.resolution
+                this_data = load_hic(
+                    hic_file=hic_file,
+                    hic_norm_file=hic_norm_file,
+                    hic_is_vc=hic_is_vc,
+                    hic_type="juicebox",
+                    hic_resolution=args.resolution,
+                    tss_hic_contribution=100,
+                    window=args.maxWindow,
+                    min_window=args.minWindow,
+                    gamma=np.nan,
+                    interpolate_nan=False,
+                )
+                this_data["dist_for_fit"] = (
+                    abs(this_data["bin1"] - this_data["bin2"]) * args.resolution
+                )
                 all_data_list.append(this_data)
-            elif args.hic_type == 'bedpe':
-                hic_file, hic_norm_file, hic_is_vc = get_hic_file(chrom, args.hicDir, hic_type='bedpe')
+            elif args.hic_type == "bedpe":
+                hic_file, hic_norm_file, hic_is_vc = get_hic_file(
+                    chrom, args.hicDir, hic_type="bedpe"
+                )
                 print("Working on {}".format(hic_file))
-                this_data = load_hic(hic_file = hic_file,
-                                     hic_type = 'bedpe',
-                                     hic_norm_file = None,
-                                     hic_is_vc = None, 
-                                     hic_resolution = None, 
-                                     tss_hic_contribution = None, 
-                                     window = None, 
-                                     min_window = None, 
-                                     gamma = None)
+                this_data = load_hic(
+                    hic_file=hic_file,
+                    hic_type="bedpe",
+                    hic_norm_file=None,
+                    hic_is_vc=None,
+                    hic_resolution=None,
+                    tss_hic_contribution=None,
+                    window=None,
+                    min_window=None,
+                    gamma=None,
+                )
 
-                #Compute distance in bins as with juicebox data. 
-                #This is needed to in order to maintain consistency, but is probably slightly less accurate.
-                #Binning also reduces noise level.
-                rawdist = abs((this_data['x2'] + this_data['x1'])/2 - (this_data['y2'] + this_data['y1'])/2)
-                this_data['dist_for_fit'] = (rawdist // args.resolution) * args.resolution
-                this_data = this_data.loc[np.logical_and(this_data['dist_for_fit'] >= args.minWindow, this_data['dist_for_fit'] <= args.maxWindow)]
+                # Compute distance in bins as with juicebox data.
+                # This is needed to in order to maintain consistency, but is probably slightly less accurate.
+                # Binning also reduces noise level.
+                rawdist = abs(
+                    (this_data["x2"] + this_data["x1"]) / 2
+                    - (this_data["y2"] + this_data["y1"]) / 2
+                )
+                this_data["dist_for_fit"] = (
+                    rawdist // args.resolution
+                ) * args.resolution
+                this_data = this_data.loc[
+                    np.logical_and(
+                        this_data["dist_for_fit"] >= args.minWindow,
+                        this_data["dist_for_fit"] <= args.maxWindow,
+                    )
+                ]
                 all_data_list.append(this_data)
             else:
-                error('invalid --hic_type')
+                error("invalid --hic_type")
 
         except Exception as e:
             print(e)
@@ -99,21 +168,27 @@ def load_hic_for_powerlaw(args):
 
     all_data = pd.concat(all_data_list)
 
-    return(all_data)
+    return all_data
+
 
 def do_powerlaw_fit(HiC):
     print("Running regression")
 
-    #TO DO:
-    #Print out mean/var plot of powerlaw relationship
-    HiC_summary = HiC.groupby('dist_for_fit').agg({'hic_contact' : 'sum'})
-    HiC_summary['hic_contact'] = HiC_summary.hic_contact / HiC_summary.hic_contact.sum() #technically this normalization should be over the entire genome (not just to maxWindow). Will only affect intercept though..
-    res = stats.linregress(np.log(HiC_summary.index), np.log(HiC_summary['hic_contact']))
+    # TO DO:
+    # Print out mean/var plot of powerlaw relationship
+    HiC_summary = HiC.groupby("dist_for_fit").agg({"hic_contact": "sum"})
+    HiC_summary["hic_contact"] = (
+        HiC_summary.hic_contact / HiC_summary.hic_contact.sum()
+    )  # technically this normalization should be over the entire genome (not just to maxWindow). Will only affect intercept though..
+    res = stats.linregress(
+        np.log(HiC_summary.index), np.log(HiC_summary["hic_contact"])
+    )
 
-    hic_mean_var = HiC.groupby('dist_for_fit').agg({'hic_contact' : ['mean','var']})
-    hic_mean_var.columns = ['mean', 'var']
+    hic_mean_var = HiC.groupby("dist_for_fit").agg({"hic_contact": ["mean", "var"]})
+    hic_mean_var.columns = ["mean", "var"]
 
     return res.slope, res.intercept, hic_mean_var
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/workflow/scripts/getVariantOverlap.py
+++ b/workflow/scripts/getVariantOverlap.py
@@ -3,35 +3,58 @@ import os
 import pandas as pd
 import numpy as np
 
+
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--all_putative')
-    parser.add_argument('--score_column', default="ABC.Score")
-    parser.add_argument('--chrom_sizes')
-    parser.add_argument('--outdir')
+    parser.add_argument("--all_putative")
+    parser.add_argument("--score_column", default="ABC.Score")
+    parser.add_argument("--chrom_sizes")
+    parser.add_argument("--outdir")
     args = parser.parse_args()
     return args
 
+
 def test_variant_overlap(args, all_putative):
-    variant_overlap_file = os.path.join(args.outdir, "EnhancerPredictionsAllPutative.ForVariantOverlap.shrunk150bp.txt.gz")
+    variant_overlap_file = os.path.join(
+        args.outdir,
+        "EnhancerPredictionsAllPutative.ForVariantOverlap.shrunk150bp.txt.gz",
+    )
     # generate predictions for variant overlap
     score_t = all_putative[args.score_column] > 0.015
-    not_promoter = all_putative['class'] != "promoter"
-    is_promoter = all_putative['class'] == "promoter"
+    not_promoter = all_putative["class"] != "promoter"
+    is_promoter = all_putative["class"] == "promoter"
     score_one = all_putative[args.score_column] > 0.1
     all_putative[(score_t & not_promoter) | (is_promoter & score_one)]
-    variant_overlap =all_putative[(score_t & not_promoter) | (is_promoter & score_one)]
+    variant_overlap = all_putative[(score_t & not_promoter) | (is_promoter & score_one)]
     # remove nan predictions
     variant_overlap_pred = variant_overlap.dropna(subset=[args.score_column])
-    variant_overlap = variant_overlap_pred.loc[variant_overlap_pred['distance']<= 2000000]
-    variant_overlap.to_csv(variant_overlap_file+".tmp", sep="\t", index=False, header=True, compression="gzip", float_format="%.6f")
+    variant_overlap = variant_overlap_pred.loc[
+        variant_overlap_pred["distance"] <= 2000000
+    ]
+    variant_overlap.to_csv(
+        variant_overlap_file + ".tmp",
+        sep="\t",
+        index=False,
+        header=True,
+        compression="gzip",
+        float_format="%.6f",
+    )
     # shrink regions
-    os.system("zcat {}.tmp 2>/dev/null | head -1 | gzip > {}".format(variant_overlap_file, variant_overlap_file))
-    os.system("zcat {}.tmp | sed 1d | bedtools slop -b -150 -g {} | gzip >> {}".format(variant_overlap_file, args.chrom_sizes, variant_overlap_file))
+    os.system(
+        "zcat {}.tmp 2>/dev/null | head -1 | gzip > {}".format(
+            variant_overlap_file, variant_overlap_file
+        )
+    )
+    os.system(
+        "zcat {}.tmp | sed 1d | bedtools slop -b -150 -g {} | gzip >> {}".format(
+            variant_overlap_file, args.chrom_sizes, variant_overlap_file
+        )
+    )
 
     print("Done.")
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     args = parse_args()
     all_putative = pd.read_csv(args.all_putative, sep="\t")
     test_variant_overlap(args, all_putative)

--- a/workflow/scripts/grabMetrics.py
+++ b/workflow/scripts/grabMetrics.py
@@ -6,32 +6,40 @@ import glob
 import argparse
 import pickle
 
+
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--macs_peaks", help="narrowPeak file output by macs2. (eg. /users/kmualim/K562/macs2_peaks.narrowPeak)")
+    parser.add_argument(
+        "--macs_peaks",
+        help="narrowPeak file output by macs2. (eg. /users/kmualim/K562/macs2_peaks.narrowPeak)",
+    )
     parser.add_argument("--preds_file", help="Prediction file output by ABC")
     parser.add_argument("--neighborhood_outdir", help="Neighborhood Directory")
     parser.add_argument("--outdir", help="Predictions Directory")
     args = parser.parse_args()
-    return args 
-    
+    return args
+
 
 def generateQCMetrics(args):
-    #prediction = "{}/EnhancerPredictionsFull.txt".format(args.preds_outdir)
-   # read prediction file
+    # prediction = "{}/EnhancerPredictionsFull.txt".format(args.preds_outdir)
+    # read prediction file
     prediction_df = pd.read_csv(args.preds_file, sep="\t")
-   # Generate QC Summary.txt in Predictions Directory
+    # Generate QC Summary.txt in Predictions Directory
     pred_metrics = GrabQCMetrics(prediction_df, args.outdir)
-   # Generate PeakFileQCSummary.txt in Peaks Directory#    
+    # Generate PeakFileQCSummary.txt in Peaks Directory#
     pred_metrics = PeakFileQC(pred_metrics, args.macs_peaks, args.outdir)
     # Appends Percentage Counts in Promoters into PeakFileQCSummary.txt
-    pred_metrics = NeighborhoodFileQC(pred_metrics, args.neighborhood_outdir, args.outdir, "DHS")
-    pred_metrics = NeighborhoodFileQC(pred_metrics, args.neighborhood_outdir, args.outdir, "H3K27ac")
-    
-    with open("{}/QCSummary.p".format(args.outdir),"wb") as f:
-        pickle.dump(pred_metrics, f) 
-    
+    pred_metrics = NeighborhoodFileQC(
+        pred_metrics, args.neighborhood_outdir, args.outdir, "DHS"
+    )
+    pred_metrics = NeighborhoodFileQC(
+        pred_metrics, args.neighborhood_outdir, args.outdir, "H3K27ac"
+    )
 
-if __name__=="__main__":
+    with open("{}/QCSummary.p".format(args.outdir), "wb") as f:
+        pickle.dump(pred_metrics, f)
+
+
+if __name__ == "__main__":
     args = parse_args()
     generateQCMetrics(args)

--- a/workflow/scripts/hic.py
+++ b/workflow/scripts/hic.py
@@ -3,26 +3,35 @@ import scipy.sparse as ssp
 import pandas as pd
 import time, os
 
+
 def get_hic_file(chromosome, hic_dir, allow_vc=True, hic_type="juicebox"):
     if hic_type == "juicebox":
         is_vc = False
         filetypes = ["KR", "INTERSCALE"]
         for filetype in filetypes:
-            hic_file = os.path.join(hic_dir, chromosome, chromosome + f".{filetype}observed.gz")
-            hic_norm = os.path.join(hic_dir, chromosome, chromosome + f".{filetype}norm.gz")
+            hic_file = os.path.join(
+                hic_dir, chromosome, chromosome + f".{filetype}observed.gz"
+            )
+            hic_norm = os.path.join(
+                hic_dir, chromosome, chromosome + f".{filetype}norm.gz"
+            )
             if hic_exists(hic_file):
                 print("Using: " + hic_file)
                 return hic_file, hic_norm, False
-            
+
         if allow_vc:
             hic_file = os.path.join(hic_dir, chromosome, chromosome + ".VCobserved.gz")
             hic_norm = os.path.join(hic_dir, chromosome, chromosome + ".VCnorm.gz")
             if hic_exists(hic_file):
-                print(f"Could not find KR normalized hic file. Using VC normalized hic file: {hic_file}")
+                print(
+                    f"Could not find KR normalized hic file. Using VC normalized hic file: {hic_file}"
+                )
                 return hic_file, hic_norm, True
 
-        raise RuntimeError(f"Could not find {', '.join(filetypes)} or VC normalized hic files")
-    
+        raise RuntimeError(
+            f"Could not find {', '.join(filetypes)} or VC normalized hic files"
+        )
+
     elif hic_type == "bedpe":
         hic_file = os.path.join(hic_dir, chromosome, chromosome + ".bedpe.gz")
         return hic_file, None, None
@@ -30,40 +39,62 @@ def get_hic_file(chromosome, hic_dir, allow_vc=True, hic_type="juicebox"):
         hic_file = os.path.join(hic_dir, chromosome, chromosome + ".bed.gz")
         return hic_file, None, None
 
+
 def hic_exists(file):
     if not os.path.exists(file):
         return False
-    elif file.endswith('gz'):
-        #gzip file still have some size. This is a hack
-        return (os.path.getsize(file) > 100)
+    elif file.endswith("gz"):
+        # gzip file still have some size. This is a hack
+        return os.path.getsize(file) > 100
     else:
-        return (os.path.getsize(file) > 0)
+        return os.path.getsize(file) > 0
 
-def load_hic(hic_file, hic_norm_file, hic_is_vc, hic_type, hic_resolution, tss_hic_contribution, window, min_window, gamma, scale=None, interpolate_nan=True, apply_diagonal_bin_correction=True):
+
+def load_hic(
+    hic_file,
+    hic_norm_file,
+    hic_is_vc,
+    hic_type,
+    hic_resolution,
+    tss_hic_contribution,
+    window,
+    min_window,
+    gamma,
+    scale=None,
+    interpolate_nan=True,
+    apply_diagonal_bin_correction=True,
+):
     print("Loading HiC")
 
-    if hic_type == 'juicebox':
+    if hic_type == "juicebox":
         HiC_sparse_mat = hic_to_sparse(hic_file, hic_norm_file, hic_resolution)
-        HiC = process_hic(hic_mat = HiC_sparse_mat, 
-                            hic_norm_file = hic_norm_file,
-                            hic_is_vc = hic_is_vc,
-                            resolution = hic_resolution, 
-                            tss_hic_contribution = tss_hic_contribution, 
-                            window = window, 
-                            min_window = min_window, 
-                            gamma = gamma,
-                            interpolate_nan = interpolate_nan,
-                            apply_diagonal_bin_correction = apply_diagonal_bin_correction,
-                            scale = scale)
-        #HiC = juicebox_to_bedpe(HiC, chromosome, args)
-    elif hic_type == 'bedpe':
-        HiC = pd.read_csv(hic_file, sep="\t", names = ['chr1','x1','x2','chr2','y1','y2','name','hic_contact'])
-    elif hic_type == 'avg':
-        HiC = pd.read_csv(hic_file, sep="\t", names = ['x1', 'x2', 'hic_contact'])
-        HiC['bin1'] = np.floor(HiC['x1'] / hic_resolution).astype(int)
-        HiC['bin2'] = np.floor(HiC['x2'] / hic_resolution).astype(int)
+        HiC = process_hic(
+            hic_mat=HiC_sparse_mat,
+            hic_norm_file=hic_norm_file,
+            hic_is_vc=hic_is_vc,
+            resolution=hic_resolution,
+            tss_hic_contribution=tss_hic_contribution,
+            window=window,
+            min_window=min_window,
+            gamma=gamma,
+            interpolate_nan=interpolate_nan,
+            apply_diagonal_bin_correction=apply_diagonal_bin_correction,
+            scale=scale,
+        )
+        # HiC = juicebox_to_bedpe(HiC, chromosome, args)
+    elif hic_type == "bedpe":
+        HiC = pd.read_csv(
+            hic_file,
+            sep="\t",
+            names=["chr1", "x1", "x2", "chr2", "y1", "y2", "name", "hic_contact"],
+        )
+    elif hic_type == "avg":
+        HiC = pd.read_csv(hic_file, sep="\t", names=["x1", "x2", "hic_contact"])
+        HiC["bin1"] = np.floor(HiC["x1"] / hic_resolution).astype(int)
+        HiC["bin2"] = np.floor(HiC["x2"] / hic_resolution).astype(int)
 
     return HiC
+
 
 # def juicebox_to_bedpe(hic, chromosome, resolution):
 #     hic['chr'] = chromosome
@@ -74,89 +105,144 @@ def load_hic(hic_file, hic_norm_file, hic_is_vc, hic_type, hic_resolution, tss_h
 
 #     return(hic)
 
-def process_hic(hic_mat, hic_norm_file, hic_is_vc, resolution, tss_hic_contribution, window, min_window=0, hic_is_doubly_stochastic=False, apply_diagonal_bin_correction=True, interpolate_nan=True, gamma=None, kr_cutoff = .25, scale=None):
-    #Make doubly stochastic.
-    #Juicer produces a matrix with constant row/column sums. But sum is not 1 and is variable across chromosomes
+
+def process_hic(
+    hic_mat,
+    hic_norm_file,
+    hic_is_vc,
+    resolution,
+    tss_hic_contribution,
+    window,
+    min_window=0,
+    hic_is_doubly_stochastic=False,
+    apply_diagonal_bin_correction=True,
+    interpolate_nan=True,
+    gamma=None,
+    kr_cutoff=0.25,
+    scale=None,
+):
+    # Make doubly stochastic.
+    # Juicer produces a matrix with constant row/column sums. But sum is not 1 and is variable across chromosomes
     t = time.time()
 
     if not hic_is_doubly_stochastic and not hic_is_vc:
-        #Any row with Nan in it will sum to nan
-        #So need to calculate sum excluding nan
+        # Any row with Nan in it will sum to nan
+        # So need to calculate sum excluding nan
         temp = hic_mat
         temp.data = np.nan_to_num(temp.data, copy=False)
-        sums = temp.sum(axis = 0)
+        sums = temp.sum(axis=0)
         sums = sums[~np.isnan(sums)]
-        #assert(np.max(sums[sums > 0])/np.min(sums[sums > 0]) < 1.001)
+        # assert(np.max(sums[sums > 0])/np.min(sums[sums > 0]) < 1.001)
         mean_sum = np.mean(sums[sums > 0])
 
-        if abs(mean_sum - 1) < .001:
-            print('HiC Matrix has row sums of {}, continuing without making doubly stochastic'.format(mean_sum))
+        if abs(mean_sum - 1) < 0.001:
+            print(
+                "HiC Matrix has row sums of {}, continuing without making doubly stochastic".format(
+                    mean_sum
+                )
+            )
         else:
-            print('HiC Matrix has row sums of {}, making doubly stochastic...'.format(mean_sum))
-            hic_mat = hic_mat.multiply(1/mean_sum)
+            print(
+                "HiC Matrix has row sums of {}, making doubly stochastic...".format(
+                    mean_sum
+                )
+            )
+            hic_mat = hic_mat.multiply(1 / mean_sum)
 
-    #Adjust diagonal of matrix based on neighboring bins
-    #First and last rows need to be treated differently
+    # Adjust diagonal of matrix based on neighboring bins
+    # First and last rows need to be treated differently
     if apply_diagonal_bin_correction:
         last_idx = hic_mat.shape[0] - 1
-        nonzero_diag = hic_mat.nonzero()[0][hic_mat.nonzero()[0] == hic_mat.nonzero()[1]]
-        nonzero_diag = list(set(nonzero_diag) - set(np.array([last_idx])) - set(np.array([0])))
+        nonzero_diag = hic_mat.nonzero()[0][
+            hic_mat.nonzero()[0] == hic_mat.nonzero()[1]
+        ]
+        nonzero_diag = list(
+            set(nonzero_diag) - set(np.array([last_idx])) - set(np.array([0]))
+        )
 
         for ii in nonzero_diag:
-            hic_mat[ii,ii] = max(hic_mat[ii,ii-1], hic_mat[ii,ii+1]) * tss_hic_contribution / 100
+            hic_mat[ii, ii] = (
+                max(hic_mat[ii, ii - 1], hic_mat[ii, ii + 1])
+                * tss_hic_contribution
+                / 100
+            )
 
-        if hic_mat[0,0] != 0:
-            hic_mat[0, 0] = hic_mat[0,1] * tss_hic_contribution / 100
+        if hic_mat[0, 0] != 0:
+            hic_mat[0, 0] = hic_mat[0, 1] * tss_hic_contribution / 100
 
         if hic_mat[last_idx, last_idx] != 0:
-            hic_mat[last_idx, last_idx] = hic_mat[last_idx, last_idx - 1] * tss_hic_contribution / 100
+            hic_mat[last_idx, last_idx] = (
+                hic_mat[last_idx, last_idx - 1] * tss_hic_contribution / 100
+            )
 
-    #Any entries with low KR norm entries get set to NaN. These will be interpolated below
+    # Any entries with low KR norm entries get set to NaN. These will be interpolated below
     hic_mat = apply_kr_threshold(hic_mat, hic_norm_file, kr_cutoff)
 
-    #Remove lower triangle
+    # Remove lower triangle
     if not hic_is_vc:
         hic_mat = ssp.triu(hic_mat)
     else:
         hic_mat = process_vc(hic_mat)
 
-    #Turn into dataframe
+    # Turn into dataframe
     hic_mat = hic_mat.tocoo(copy=False)
-    hic_df = pd.DataFrame({'bin1': hic_mat.row, 'bin2': hic_mat.col, 'hic_contact': hic_mat.data})
+    hic_df = pd.DataFrame(
+        {"bin1": hic_mat.row, "bin2": hic_mat.col, "hic_contact": hic_mat.data}
+    )
 
-    #Prune to window
-    hic_df = hic_df.loc[np.logical_and(abs(hic_df['bin1'] - hic_df['bin2']) <= window/resolution, abs(hic_df['bin1'] - hic_df['bin2']) >= min_window/resolution)]
-    print("HiC has {} rows after windowing between {} and {}".format(hic_df.shape[0], min_window, window))
+    # Prune to window
+    hic_df = hic_df.loc[
+        np.logical_and(
+            abs(hic_df["bin1"] - hic_df["bin2"]) <= window / resolution,
+            abs(hic_df["bin1"] - hic_df["bin2"]) >= min_window / resolution,
+        )
+    ]
+    print(
+        "HiC has {} rows after windowing between {} and {}".format(
+            hic_df.shape[0], min_window, window
+        )
+    )
 
-    hic_df['juicebox_contact_values'] = hic_df['hic_contact']
-    #Fill NaN
-    #NaN in the KR normalized matrix are not zeros. They are entries where the KR algorithm did not converge (or low KR norm)
-    #So need to fill these. Use powerlaw. 
-    #Not ideal obviously but the scipy interpolation algos are either very slow or don't work since the nan structure implies that not all nans are interpolated
+    hic_df["juicebox_contact_values"] = hic_df["hic_contact"]
+    # Fill NaN
+    # NaN in the KR normalized matrix are not zeros. They are entries where the KR algorithm did not converge (or low KR norm)
+    # So need to fill these. Use powerlaw.
+    # Not ideal obviously but the scipy interpolation algos are either very slow or don't work since the nan structure implies that not all nans are interpolated
     if interpolate_nan:
-        nan_loc = np.isnan(hic_df['hic_contact'])
-        hic_df.loc[nan_loc,'hic_contact'] = get_powerlaw_at_distance(abs(hic_df.loc[nan_loc,'bin1'] - hic_df.loc[nan_loc,'bin2']) * resolution, gamma, min_distance=resolution, scale=scale)
+        nan_loc = np.isnan(hic_df["hic_contact"])
+        hic_df.loc[nan_loc, "hic_contact"] = get_powerlaw_at_distance(
+            abs(hic_df.loc[nan_loc, "bin1"] - hic_df.loc[nan_loc, "bin2"]) * resolution,
+            gamma,
+            min_distance=resolution,
+            scale=scale,
+        )
 
-    print('process.hic: Elapsed time: {}'.format(time.time() - t))
+    print("process.hic: Elapsed time: {}".format(time.time() - t))
 
+    return hic_df
 
-    return(hic_df)
 
 def apply_kr_threshold(hic_mat, hic_norm_file, kr_cutoff):
-    #Convert all entries in the hic matrix corresponding to low kr norm entries to NaN
-    #Note that in scipy sparse matrix multiplication 0*nan = 0
-    #So this doesn't convert 0's to nan only nonzero to nan
+    # Convert all entries in the hic matrix corresponding to low kr norm entries to NaN
+    # Note that in scipy sparse matrix multiplication 0*nan = 0
+    # So this doesn't convert 0's to nan only nonzero to nan
     norms = np.loadtxt(hic_norm_file)
     norms[norms < kr_cutoff] = np.nan
     norms[norms >= kr_cutoff] = 1
-    norm_mat = ssp.dia_matrix(( 1.0/norms, [0]), (len(norms), len(norms)))
+    norm_mat = ssp.dia_matrix((1.0 / norms, [0]), (len(norms), len(norms)))
 
     return norm_mat * hic_mat * norm_mat
 
+
 def hic_to_sparse(filename, norm_file, resolution, hic_is_doubly_stochastic=False):
     t = time.time()
-    HiC = pd.read_table(filename, names=["bin1", "bin2", "hic_contact"],
-                        header=None, engine='c', memory_map=True)
+    HiC = pd.read_table(
+        filename,
+        names=["bin1", "bin2", "hic_contact"],
+        header=None,
+        engine="c",
+        memory_map=True,
+    )
 
     # verify our assumptions
     assert np.all(HiC.bin1 <= HiC.bin2)
@@ -172,12 +258,12 @@ def hic_to_sparse(filename, norm_file, resolution, hic_is_doubly_stochastic=Fals
     col = np.floor(HiC.bin2.values / resolution).astype(int)
     dat = HiC.hic_contact.values
 
-    #JN: Need both triangles in order to compute row/column sums to make double stochastic.
-    #If juicebox is upgraded to return DS matrices, then can remove one triangle
-    #TO DO: Remove one triangle when juicebox is updated.
+    # JN: Need both triangles in order to compute row/column sums to make double stochastic.
+    # If juicebox is upgraded to return DS matrices, then can remove one triangle
+    # TO DO: Remove one triangle when juicebox is updated.
     # we want a symmetric matrix.  Easiest to do that during creation, but have to be careful of diagonal
     if not hic_is_doubly_stochastic:
-        mask = (row != col)  # off-diagonal
+        mask = row != col  # off-diagonal
         row2 = col[mask]  # note the row/col swap
         col2 = row[mask]
         dat2 = dat[mask]
@@ -187,46 +273,49 @@ def hic_to_sparse(filename, norm_file, resolution, hic_is_doubly_stochastic=Fals
         col = np.hstack((col, col2))
         dat = np.hstack((dat, dat2))
 
-    print('hic.to.sparse: Elapsed time: {}'.format(time.time() - t))
+    print("hic.to.sparse: Elapsed time: {}".format(time.time() - t))
 
     return ssp.csr_matrix((dat, (row, col)), (hic_size, hic_size))
 
-def get_powerlaw_at_distance(distances, gamma, min_distance=5000, scale=None):
-    assert(gamma > 0)
 
-    #The powerlaw is computed for distances > 5kb. We don't know what the contact freq looks like at < 5kb.
-    #So just assume that everything at < 5kb is equal to 5kb.
-    #TO DO: get more accurate powerlaw at < 5kb
+def get_powerlaw_at_distance(distances, gamma, min_distance=5000, scale=None):
+    assert gamma > 0
+
+    # The powerlaw is computed for distances > 5kb. We don't know what the contact freq looks like at < 5kb.
+    # So just assume that everything at < 5kb is equal to 5kb.
+    # TO DO: get more accurate powerlaw at < 5kb
     distances = np.clip(distances, min_distance, np.Inf)
     log_dists = np.log(distances + 1)
 
-    #Determine scale parameter
-    #A powerlaw distribution has two parameters: the exponent and the minimum domain value 
-    #In our case, the minimum domain value is always constant (equal to 1 HiC bin) so there should only be 1 parameter
-    #The current fitting approach does a linear regression in log-log space which produces both a slope (gamma) and a intercept (scale)
-    #Empirically there is a linear relationship between these parameters (which makes sense since we expect only a single parameter distribution)
-    #It should be possible to analytically solve for scale using gamma. But this doesn't quite work since the hic data does not actually follow a power-law
-    #So could pass in the scale parameter explicity here. Or just kludge it as I'm doing now
-    #TO DO: Eventually the pseudocount should be replaced with a more appropriate smoothing procedure.
+    # Determine scale parameter
+    # A powerlaw distribution has two parameters: the exponent and the minimum domain value
+    # In our case, the minimum domain value is always constant (equal to 1 HiC bin) so there should only be 1 parameter
+    # The current fitting approach does a linear regression in log-log space which produces both a slope (gamma) and a intercept (scale)
+    # Empirically there is a linear relationship between these parameters (which makes sense since we expect only a single parameter distribution)
+    # It should be possible to analytically solve for scale using gamma. But this doesn't quite work since the hic data does not actually follow a power-law
+    # So could pass in the scale parameter explicity here. Or just kludge it as I'm doing now
+    # TO DO: Eventually the pseudocount should be replaced with a more appropriate smoothing procedure.
 
-    #4.80 and 11.63 come from a linear regression of scale on gamma across 20 hic cell types at 5kb resolution. Do the params change across resolutions?
+    # 4.80 and 11.63 come from a linear regression of scale on gamma across 20 hic cell types at 5kb resolution. Do the params change across resolutions?
     if scale is None:
         scale = -4.80 + 11.63 * gamma
 
-    powerlaw_contact = np.exp(scale + -1*gamma * log_dists)
+    powerlaw_contact = np.exp(scale + -1 * gamma * log_dists)
 
-    return(powerlaw_contact)
+    return powerlaw_contact
+
 
 def process_vc(hic):
-    #For a vc normalized matrix, need to make rows sum to 1. 
-    #Assume rows correspond to genes and cols to enhancers
+    # For a vc normalized matrix, need to make rows sum to 1.
+    # Assume rows correspond to genes and cols to enhancers
 
-    row_sums = hic.sum(axis = 0)
+    row_sums = hic.sum(axis=0)
     row_sums[row_sums == 0] = 1
-    norm_mat = ssp.dia_matrix((1.0 / row_sums, [0]), (row_sums.shape[1], row_sums.shape[1]))
+    norm_mat = ssp.dia_matrix(
+        (1.0 / row_sums, [0]), (row_sums.shape[1], row_sums.shape[1])
+    )
 
-    #left multiply to operate on rows
+    # left multiply to operate on rows
     hic = norm_mat * hic
 
-    return(hic)
-
+    return hic

--- a/workflow/scripts/juicebox_dump.py
+++ b/workflow/scripts/juicebox_dump.py
@@ -2,54 +2,90 @@ import argparse
 import subprocess
 from tools import run_command
 
+
 def parseargs():
-    parser = argparse.ArgumentParser(description='Download and dump HiC data')
-    parser.add_argument('--hic_file', required=True, help="Path or url to .hic file.")
-    parser.add_argument('--juicebox', required=True, default="", help="path to juicebox executable or java command invoking juicer_tools.jar. eg: 'java -jar juicer_tools.jar'")
-    parser.add_argument('--resolution', default=5000, help="Resolution of HiC to download. In units of bp.")
-    parser.add_argument('--outdir', default=".")
-    parser.add_argument('--include_raw', action="store_true", help="Download raw matrix in addtion to KR")
-    parser.add_argument('--chromosomes', default="all", help="comma delimited list of chromosomes to download")
-    parser.add_argument('--skip_gzip', action="store_true", help="dont gzip hic files")
+    parser = argparse.ArgumentParser(description="Download and dump HiC data")
+    parser.add_argument("--hic_file", required=True, help="Path or url to .hic file.")
+    parser.add_argument(
+        "--juicebox",
+        required=True,
+        default="",
+        help="path to juicebox executable or java command invoking juicer_tools.jar. eg: 'java -jar juicer_tools.jar'",
+    )
+    parser.add_argument(
+        "--resolution",
+        default=5000,
+        help="Resolution of HiC to download. In units of bp.",
+    )
+    parser.add_argument("--outdir", default=".")
+    parser.add_argument(
+        "--include_raw",
+        action="store_true",
+        help="Download raw matrix in addtion to KR",
+    )
+    parser.add_argument(
+        "--chromosomes",
+        default="all",
+        help="comma delimited list of chromosomes to download",
+    )
+    parser.add_argument("--skip_gzip", action="store_true", help="dont gzip hic files")
 
     return parser.parse_args()
 
-def main(args):
 
+def main(args):
     if args.chromosomes == "all":
-        chromosomes = list(range(1,23)) + ['X']
+        chromosomes = list(range(1, 23)) + ["X"]
     else:
         chromosomes = args.chromosomes.split(",")
 
     for chromosome in chromosomes:
-        import pdb; pdb.set_trace()
+        import pdb
+
+        pdb.set_trace()
         print("Starting chr" + str(chromosome) + " ... ")
         outdir = "{0}/chr{1}/".format(args.outdir, chromosome)
         command = "mkdir -p " + outdir
         out = subprocess.getoutput(command)
 
         ## Download observed matrix with KR normalization
-        command = args.juicebox + " dump observed KR {0} {1} {1} BP {3} {2}chr{1}.KRobserved".format(args.hic_file, chromosome, outdir, args.resolution)
+        command = (
+            args.juicebox
+            + " dump observed KR {0} {1} {1} BP {3} {2}chr{1}.KRobserved".format(
+                args.hic_file, chromosome, outdir, args.resolution
+            )
+        )
         print(command)
         out = subprocess.getoutput(command)
-        if not args.skip_gzip: 
+        if not args.skip_gzip:
             run_command("gzip {0}chr{1}.KRobserved".format(outdir, chromosome))
 
         ## Download KR norm file
-        command = args.juicebox + " dump norm KR {0} {1} BP {3} {2}chr{1}.KRnorm".format(args.hic_file, chromosome, outdir, args.resolution)
+        command = (
+            args.juicebox
+            + " dump norm KR {0} {1} BP {3} {2}chr{1}.KRnorm".format(
+                args.hic_file, chromosome, outdir, args.resolution
+            )
+        )
         out = subprocess.getoutput(command)
         print(command)
-        if not args.skip_gzip: 
+        if not args.skip_gzip:
             run_command("gzip {0}chr{1}.KRnorm".format(outdir, chromosome))
-        
+
         if args.include_raw:
             ## Download raw observed matrix
-            command = args.juicebox + " dump observed NONE {0} {1} {1} BP {3} {2}chr{1}.RAWobserved".format(args.hic_file, chromosome, outdir, args.resolution)
+            command = (
+                args.juicebox
+                + " dump observed NONE {0} {1} {1} BP {3} {2}chr{1}.RAWobserved".format(
+                    args.hic_file, chromosome, outdir, args.resolution
+                )
+            )
             print(command)
             out = subprocess.getoutput(command)
             if not args.skip_gzip:
                 run_command("gzip {0}chr{1}.RAWobserved".format(outdir, chromosome))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     args = parseargs()
     main(args)

--- a/workflow/scripts/makeAverageHiC.py
+++ b/workflow/scripts/makeAverageHiC.py
@@ -6,144 +6,201 @@ import sys, os, os.path
 from tools import write_params
 import pyranges
 
+
 # To do
 # Final output matrix needs to be KR normed as well
 def parseargs():
-    class formatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter):
+    class formatter(
+        argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter
+    ):
         pass
 
-    epilog = ("")
-    parser = argparse.ArgumentParser(description='Make average HiC dataset',
-                                     epilog=epilog,
-                                     formatter_class=formatter)
-    readable = argparse.FileType('r')
-    parser.add_argument('--celltypes', required=True, help="Comma delimitted list of cell types")
-    parser.add_argument('--chromosome', required=True, help="Chromosome to compute on")
-    parser.add_argument('--basedir', required=True, help="Basedir")
-    parser.add_argument('--outDir', required=True, help="Output directory")
-    parser.add_argument('--resolution', default=5000, type=int, help="Resolution of hic dataset (in bp)")
-    parser.add_argument('--ref_scale', default=5.41, type=float, help="Reference scale parameter")
-    parser.add_argument('--ref_gamma', default=-.876, type=float, help="Reference gamma parameter")
-    parser.add_argument('--min_cell_types_required', default=3, type=int, help="Minimum number of non-nan entries required to calculate average for a hic bin")
+    epilog = ""
+    parser = argparse.ArgumentParser(
+        description="Make average HiC dataset", epilog=epilog, formatter_class=formatter
+    )
+    readable = argparse.FileType("r")
+    parser.add_argument(
+        "--celltypes", required=True, help="Comma delimitted list of cell types"
+    )
+    parser.add_argument("--chromosome", required=True, help="Chromosome to compute on")
+    parser.add_argument("--basedir", required=True, help="Basedir")
+    parser.add_argument("--outDir", required=True, help="Output directory")
+    parser.add_argument(
+        "--resolution", default=5000, type=int, help="Resolution of hic dataset (in bp)"
+    )
+    parser.add_argument(
+        "--ref_scale", default=5.41, type=float, help="Reference scale parameter"
+    )
+    parser.add_argument(
+        "--ref_gamma", default=-0.876, type=float, help="Reference gamma parameter"
+    )
+    parser.add_argument(
+        "--min_cell_types_required",
+        default=3,
+        type=int,
+        help="Minimum number of non-nan entries required to calculate average for a hic bin",
+    )
 
     args = parser.parse_args()
-    return(args)
+    return args
+
 
 def main():
     args = parseargs()
     os.makedirs(args.outDir, exist_ok=True)
 
-    #Write params file
+    # Write params file
     write_params(args, os.path.join(args.outDir, "params.txt"))
 
-    #Parse cell types
+    # Parse cell types
     cell_types = args.celltypes.split(",")
 
-    # chromosomes = ['chr' + str(x) for x in range(1,23)] + ['chrX'] 
+    # chromosomes = ['chr' + str(x) for x in range(1,23)] + ['chrX']
     # chromosomes = ['chr22']
 
     special_value = np.Inf
 
-    #for chromosome in chromosomes:
-    hic_list = [process_chr(cell_type, args.chromosome, args.basedir, args.resolution, args.ref_scale, args.ref_gamma, special_value) for cell_type in cell_types]
+    # for chromosome in chromosomes:
+    hic_list = [
+        process_chr(
+            cell_type,
+            args.chromosome,
+            args.basedir,
+            args.resolution,
+            args.ref_scale,
+            args.ref_gamma,
+            special_value,
+        )
+        for cell_type in cell_types
+    ]
     hic_list = [x for x in hic_list if x is not None]
-    hic_list = [df.set_index(['bin1','bin2']) for df in hic_list]
+    hic_list = [df.set_index(["bin1", "bin2"]) for df in hic_list]
 
-    #Make average
-    #Merge all hic matrices
-    #Need to deal with nan vs 0 here. In the KR normalized matrices there are nan which we want to deal as missing. 
-    #Rows that are not present in the hic dataframe should be considered 0
-    #But after doing an outer join these rows will be represented as nan in the merged dataframe.
-    #So need a way to distinguish nan vs 0.
-    #Hack: convert all nan in the celltype specific hic dataframes to a special value. Then replace this special value after merging
-    #TO DO: This is very memory intensive! (consider pandas.join or pandas.concat)
+    # Make average
+    # Merge all hic matrices
+    # Need to deal with nan vs 0 here. In the KR normalized matrices there are nan which we want to deal as missing.
+    # Rows that are not present in the hic dataframe should be considered 0
+    # But after doing an outer join these rows will be represented as nan in the merged dataframe.
+    # So need a way to distinguish nan vs 0.
+    # Hack: convert all nan in the celltype specific hic dataframes to a special value. Then replace this special value after merging
+    # TO DO: This is very memory intensive! (consider pandas.join or pandas.concat)
     # import pdb
     # pdb.set_trace()
 
-    all_hic = pd.concat(hic_list, axis=1, join='outer', copy=False)
-    hic_list = None #Clear from memory
+    all_hic = pd.concat(hic_list, axis=1, join="outer", copy=False)
+    hic_list = None  # Clear from memory
 
     # import pdb
     # pdb.set_trace()
 
-    #all_hic = pd.DataFrame().join(hic_list, how="outer", on=['bin1','bin2'])
-    #all_hic = reduce(lambda x, y: pd.merge(x, y, on = ['bin1', 'bin2'], how = 'outer'), hic_list)
+    # all_hic = pd.DataFrame().join(hic_list, how="outer", on=['bin1','bin2'])
+    # all_hic = reduce(lambda x, y: pd.merge(x, y, on = ['bin1', 'bin2'], how = 'outer'), hic_list)
     all_hic.fillna(value=0, inplace=True)
-    all_hic.replace(to_replace = special_value, value = np.nan, inplace=True)
+    all_hic.replace(to_replace=special_value, value=np.nan, inplace=True)
 
-    #compute the average
-    cols_for_avg = list(filter(lambda x:'hic_kr' in x, all_hic.columns))
-    
-    #all_hic['avg_hic'] = all_hic[cols_for_avg].mean(axis=1)
-    #avg_hic = all_hic[cols_for_avg].mean(axis=1)
+    # compute the average
+    cols_for_avg = list(filter(lambda x: "hic_kr" in x, all_hic.columns))
+
+    # all_hic['avg_hic'] = all_hic[cols_for_avg].mean(axis=1)
+    # avg_hic = all_hic[cols_for_avg].mean(axis=1)
     avg_hic = all_hic.mean(axis=1)
     num_good = len(cols_for_avg) - np.isnan(all_hic).sum(axis=1)
 
-    #Check minimum number of cols
+    # Check minimum number of cols
     all_hic.drop(cols_for_avg, inplace=True, axis=1)
     all_hic.reset_index(level=all_hic.index.names, inplace=True)
-    all_hic['avg_hic'] = avg_hic.values
-    all_hic.loc[num_good.values < args.min_cell_types_required, 'avg_hic'] = np.nan
+    all_hic["avg_hic"] = avg_hic.values
+    all_hic.loc[num_good.values < args.min_cell_types_required, "avg_hic"] = np.nan
 
-    #Setup final matrix
-    all_hic['bin1'] = all_hic['bin1'] * args.resolution
-    all_hic['bin2'] = all_hic['bin2'] * args.resolution
-    all_hic = all_hic.loc[np.logical_or(all_hic['avg_hic'] > 0, np.isnan(all_hic['avg_hic'])), ] # why do these 0's exist?
+    # Setup final matrix
+    all_hic["bin1"] = all_hic["bin1"] * args.resolution
+    all_hic["bin2"] = all_hic["bin2"] * args.resolution
+    all_hic = all_hic.loc[
+        np.logical_or(all_hic["avg_hic"] > 0, np.isnan(all_hic["avg_hic"])),
+    ]  # why do these 0's exist?
 
     os.makedirs(os.path.join(args.outDir, args.chromosome), exist_ok=True)
-    all_hic.to_csv(os.path.join(args.outDir, args.chromosome, args.chromosome + ".avg.gz"), sep="\t", header=False, index=False, compression="gzip", na_rep=np.nan)
+    all_hic.to_csv(
+        os.path.join(args.outDir, args.chromosome, args.chromosome + ".avg.gz"),
+        sep="\t",
+        header=False,
+        index=False,
+        compression="gzip",
+        na_rep=np.nan,
+    )
+
 
 def scale_hic_with_powerlaw(hic, resolution, scale_ref, gamma_ref, scale, gamma):
-
-    #get_powerlaw_at_distance expects positive gamma
+    # get_powerlaw_at_distance expects positive gamma
     gamma_ref = -1 * gamma_ref
     gamma = -1 * gamma
 
-    dists = (hic['bin2'] - hic['bin1']) * resolution
-    pl_ref = get_powerlaw_at_distance(dists, gamma_ref, scale_ref) 
+    dists = (hic["bin2"] - hic["bin1"]) * resolution
+    pl_ref = get_powerlaw_at_distance(dists, gamma_ref, scale_ref)
     pl = get_powerlaw_at_distance(dists, gamma, scale)
 
-    hic['hic_kr'] = hic['hic_kr'] * (pl_ref / pl)
+    hic["hic_kr"] = hic["hic_kr"] * (pl_ref / pl)
 
     return hic
 
-def process_chr(cell_type, chromosome, basedir, resolution, scale_ref, gamma_ref, special_value):
 
+def process_chr(
+    cell_type, chromosome, basedir, resolution, scale_ref, gamma_ref, special_value
+):
     # import pdb
     # pdb.set_trace()
 
-    hic_file, hic_norm_file, is_vc = get_hic_file(chromosome, os.path.join(basedir, cell_type, "5kb_resolution_intra"), allow_vc = True)
+    hic_file, hic_norm_file, is_vc = get_hic_file(
+        chromosome,
+        os.path.join(basedir, cell_type, "5kb_resolution_intra"),
+        allow_vc=True,
+    )
     if is_vc:
         return None
     # hic_file = os.path.join(basedir, cell_type, "5kb_resolution_intra", chromosome, chromosome + ".KRobserved")
     # hic_norm_file = os.path.join(basedir, cell_type, "5kb_resolution_intra", chromosome, chromosome + ".KRnorm")
 
-    #Load gamma and scale
-    pl_summary = pd.read_csv(os.path.join(basedir, cell_type, "5kb_resolution_intra/powerlaw/hic.powerlaw.txt"), sep="\t")
+    # Load gamma and scale
+    pl_summary = pd.read_csv(
+        os.path.join(
+            basedir, cell_type, "5kb_resolution_intra/powerlaw/hic.powerlaw.txt"
+        ),
+        sep="\t",
+    )
 
-    #Read in and normalize to make DS
-    hic = load_hic(hic_file = hic_file, 
-                    hic_norm_file = hic_norm_file,
-                    hic_is_vc=False,
-                    hic_type="juicebox", 
-                    hic_resolution = resolution, 
-                    tss_hic_contribution=np.NaN, 
-                    window = np.Inf, 
-                    min_window=0, 
-                    gamma = -1*pl_summary['pl_gamma'].values[0],
-                    interpolate_nan=False, 
-                    apply_diagonal_bin_correction=False)
+    # Read in and normalize to make DS
+    hic = load_hic(
+        hic_file=hic_file,
+        hic_norm_file=hic_norm_file,
+        hic_is_vc=False,
+        hic_type="juicebox",
+        hic_resolution=resolution,
+        tss_hic_contribution=np.NaN,
+        window=np.Inf,
+        min_window=0,
+        gamma=-1 * pl_summary["pl_gamma"].values[0],
+        interpolate_nan=False,
+        apply_diagonal_bin_correction=False,
+    )
 
-    #power law scale 
-    hic = scale_hic_with_powerlaw(hic, resolution, scale_ref, gamma_ref, scale = pl_summary['pl_scale'].values[0], gamma = pl_summary['pl_gamma'].values[0])
+    # power law scale
+    hic = scale_hic_with_powerlaw(
+        hic,
+        resolution,
+        scale_ref,
+        gamma_ref,
+        scale=pl_summary["pl_scale"].values[0],
+        gamma=pl_summary["pl_gamma"].values[0],
+    )
 
-    #fill nan in hic matrix with special value
-    #this will be turned back to nan after merging
-    assert(not np.any(hic['hic_kr'].values == special_value))
-    hic.loc[np.isnan(hic['hic_kr']), 'hic_kr'] = special_value
+    # fill nan in hic matrix with special value
+    # this will be turned back to nan after merging
+    assert not np.any(hic["hic_kr"].values == special_value)
+    hic.loc[np.isnan(hic["hic_kr"]), "hic_kr"] = special_value
 
     return hic
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/workflow/scripts/makeCandidateRegions.py
+++ b/workflow/scripts/makeCandidateRegions.py
@@ -6,67 +6,110 @@ from peaks import *
 import traceback
 from tools import write_params
 
+
 def parseargs(required_args=True):
-    class formatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter):
+    class formatter(
+        argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter
+    ):
         pass
 
-    epilog = ("")
-    parser = argparse.ArgumentParser(description='Make peaks file for a given cell type',
-                                     epilog=epilog,
-                                     formatter_class=formatter)
-    readable = argparse.FileType('r')
-    
-    parser.add_argument('--narrowPeak', required=required_args, help="narrowPeak file output by macs2. Must include summits (--call-summits)")
-    parser.add_argument('--bam', required=required_args, nargs='?', help="DNAase-Seq or ATAC-Seq bam file")
-    parser.add_argument('--chrom_sizes', required=required_args, help="File listing chromosome size annotaions")
-    parser.add_argument('--outDir', required=required_args)
-    
-    parser.add_argument('--nStrongestPeaks', default=175000, help="Number of peaks to use for defining candidate regions")
-    parser.add_argument('--peakExtendFromSummit', default=250, help="Number of base pairs to extend each preak from its summit (or from both ends of region if using --ignoreSummits)")
-    parser.add_argument('--ignoreSummits', action="store_true", help="Compute peaks using the full peak regions, rather than extending from summit.")
-    parser.add_argument('--minPeakWidth', default=500, help="Candidate regions whose width is below this threshold are expanded to this width. Only used with --ignoreSummits")
+    epilog = ""
+    parser = argparse.ArgumentParser(
+        description="Make peaks file for a given cell type",
+        epilog=epilog,
+        formatter_class=formatter,
+    )
+    readable = argparse.FileType("r")
 
-    parser.add_argument('--regions_includelist', default="", help="Bed file of regions to forcibly include in candidate enhancers. Overrides regions_blocklist")
-    parser.add_argument('--regions_blocklist', default="", help="Bed file of regions to forcibly exclude from candidate enhancers")
-    
+    parser.add_argument(
+        "--narrowPeak",
+        required=required_args,
+        help="narrowPeak file output by macs2. Must include summits (--call-summits)",
+    )
+    parser.add_argument(
+        "--bam",
+        required=required_args,
+        nargs="?",
+        help="DNAase-Seq or ATAC-Seq bam file",
+    )
+    parser.add_argument(
+        "--chrom_sizes",
+        required=required_args,
+        help="File listing chromosome size annotaions",
+    )
+    parser.add_argument("--outDir", required=required_args)
+
+    parser.add_argument(
+        "--nStrongestPeaks",
+        default=175000,
+        help="Number of peaks to use for defining candidate regions",
+    )
+    parser.add_argument(
+        "--peakExtendFromSummit",
+        default=250,
+        help="Number of base pairs to extend each preak from its summit (or from both ends of region if using --ignoreSummits)",
+    )
+    parser.add_argument(
+        "--ignoreSummits",
+        action="store_true",
+        help="Compute peaks using the full peak regions, rather than extending from summit.",
+    )
+    parser.add_argument(
+        "--minPeakWidth",
+        default=500,
+        help="Candidate regions whose width is below this threshold are expanded to this width. Only used with --ignoreSummits",
+    )
+
+    parser.add_argument(
+        "--regions_includelist",
+        default="",
+        help="Bed file of regions to forcibly include in candidate enhancers. Overrides regions_blocklist",
+    )
+    parser.add_argument(
+        "--regions_blocklist",
+        default="",
+        help="Bed file of regions to forcibly exclude from candidate enhancers",
+    )
+
     args = parser.parse_args()
-    return(args)
+    return args
+
 
 def processCellType(args):
     os.makedirs(os.path.join(args.outDir), exist_ok=True)
     write_params(args, os.path.join(args.outDir, "params.txt"))
-    
-    #Make candidate regions
+
+    # Make candidate regions
     if not args.ignoreSummits:
-        make_candidate_regions_from_summits(macs_peaks = args.narrowPeak, 
-                                            #accessibility_file = args.bam, 
-                                            accessibility_file= args.bam.split(","),
-                                            genome_sizes = args.chrom_sizes, 
-                                            regions_includelist = args.regions_includelist,
-                                            regions_blocklist = args.regions_blocklist,
-                                            n_enhancers = args.nStrongestPeaks, 
-                                            peak_extend = args.peakExtendFromSummit, 
-                                            outdir = args.outDir)
+        make_candidate_regions_from_summits(
+            macs_peaks=args.narrowPeak,
+            # accessibility_file = args.bam,
+            accessibility_file=args.bam.split(","),
+            genome_sizes=args.chrom_sizes,
+            regions_includelist=args.regions_includelist,
+            regions_blocklist=args.regions_blocklist,
+            n_enhancers=args.nStrongestPeaks,
+            peak_extend=args.peakExtendFromSummit,
+            outdir=args.outDir,
+        )
     else:
-        make_candidate_regions_from_peaks(macs_peaks = args.narrowPeak, 
-                                    accessibility_file = args.bam, 
-                                    genome_sizes = args.chrom_sizes, 
-                                    regions_includelist = args.regions_includelist,
-                                    regions_blocklist = args.regions_blocklist,
-                                    n_enhancers = args.nStrongestPeaks, 
-                                    peak_extend = args.peakExtendFromSummit, 
-                                    minPeakWidth = args.minPeakWidth,
-                                    outdir = args.outDir)
-                                    
+        make_candidate_regions_from_peaks(
+            macs_peaks=args.narrowPeak,
+            accessibility_file=args.bam,
+            genome_sizes=args.chrom_sizes,
+            regions_includelist=args.regions_includelist,
+            regions_blocklist=args.regions_blocklist,
+            n_enhancers=args.nStrongestPeaks,
+            peak_extend=args.peakExtendFromSummit,
+            minPeakWidth=args.minPeakWidth,
+            outdir=args.outDir,
+        )
 
 
 def main(args):
     processCellType(args)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     args = parseargs()
     main(args)
-
-
-
-

--- a/workflow/scripts/make_bedgraph_from_HiC.py
+++ b/workflow/scripts/make_bedgraph_from_HiC.py
@@ -7,83 +7,137 @@ import numpy as np
 import sys
 from neighborhoods import read_bed, process_gene_bed
 
+
 def parseargs():
-    parser = argparse.ArgumentParser(description='Convert HiC matrices to bedgraphs for a set of genes')
-    parser.add_argument('--outdir', required=True, help="directory to write HiC bedgraphs")
-    parser.add_argument('--hic_dir', required=True, help="location of HiC data")
-    
-    #Genes    
-    parser.add_argument('--genes', required=True, help=".bed file of genes")
-    parser.add_argument('--gene_name_annotations', default="symbol", help="Comma delimited string of names corresponding to the gene identifiers present in the name field of the gene annotation bed file")
-    parser.add_argument('--primary_gene_identifier', default="symbol", help="Primary identifier used to identify genes. Must be present in gene_name_annotations")
+    parser = argparse.ArgumentParser(
+        description="Convert HiC matrices to bedgraphs for a set of genes"
+    )
+    parser.add_argument(
+        "--outdir", required=True, help="directory to write HiC bedgraphs"
+    )
+    parser.add_argument("--hic_dir", required=True, help="location of HiC data")
 
-    #HiC Params
-    parser.add_argument('--resolution', type=int, default=5000, help="HiC resolution to use")
-    parser.add_argument('--kr_cutoff', type=float, default=0.1, help="Measured data from Hi-C matrix for rows/columns with kr normalization vector below this value are not used. Instead they are interpolated from neighboring bins")
-    parser.add_argument('--window', type=int, default=5000000, help="maximum distance from each TSS to store (bp)")
+    # Genes
+    parser.add_argument("--genes", required=True, help=".bed file of genes")
+    parser.add_argument(
+        "--gene_name_annotations",
+        default="symbol",
+        help="Comma delimited string of names corresponding to the gene identifiers present in the name field of the gene annotation bed file",
+    )
+    parser.add_argument(
+        "--primary_gene_identifier",
+        default="symbol",
+        help="Primary identifier used to identify genes. Must be present in gene_name_annotations",
+    )
 
-    parser.add_argument('--overwrite', action="store_true", help="force overwriting files")
+    # HiC Params
+    parser.add_argument(
+        "--resolution", type=int, default=5000, help="HiC resolution to use"
+    )
+    parser.add_argument(
+        "--kr_cutoff",
+        type=float,
+        default=0.1,
+        help="Measured data from Hi-C matrix for rows/columns with kr normalization vector below this value are not used. Instead they are interpolated from neighboring bins",
+    )
+    parser.add_argument(
+        "--window",
+        type=int,
+        default=5000000,
+        help="maximum distance from each TSS to store (bp)",
+    )
+
+    parser.add_argument(
+        "--overwrite", action="store_true", help="force overwriting files"
+    )
 
     return parser.parse_args()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = parseargs()
 
     def match_files(*subdirs):
         return glob.glob(os.path.join(args.hic_dir, *subdirs))
 
-    #Read genes
-    genes_bed = read_bed(args.genes) 
-    genes = process_gene_bed(genes_bed, args.gene_name_annotations, args.primary_gene_identifier, fail_on_nonunique=False)
+    # Read genes
+    genes_bed = read_bed(args.genes)
+    genes = process_gene_bed(
+        genes_bed,
+        args.gene_name_annotations,
+        args.primary_gene_identifier,
+        fail_on_nonunique=False,
+    )
 
-    #Get raw hic and normalization files
-    resolution = '{}kb'.format(args.resolution // 1000)
+    # Get raw hic and normalization files
+    resolution = "{}kb".format(args.resolution // 1000)
     hic_files = {}
-    for chr in set(genes['chr']):
-        possible_files = match_files('{}'.format(chr), '{}_{}.RAWobserved'.format(chr, resolution))
-        possible_norms = match_files('{}'.format(chr), '{}_{}.KRnorm'.format(chr, resolution))
+    for chr in set(genes["chr"]):
+        possible_files = match_files(
+            "{}".format(chr), "{}_{}.RAWobserved".format(chr, resolution)
+        )
+        possible_norms = match_files(
+            "{}".format(chr), "{}_{}.KRnorm".format(chr, resolution)
+        )
 
         if possible_files:
-            hic_files['{}'.format(chr)] = (possible_files[0], possible_norms[0])
+            hic_files["{}".format(chr)] = (possible_files[0], possible_norms[0])
 
     # create data accessor
-    hic_data = HiC(hic_files, window=args.window, resolution=args.resolution, kr_cutoff=args.kr_cutoff)
+    hic_data = HiC(
+        hic_files,
+        window=args.window,
+        resolution=args.resolution,
+        kr_cutoff=args.kr_cutoff,
+    )
 
     # create output directory
     os.makedirs(args.outdir, exist_ok=True)
-    #os.makedirs(os.path.join(args.outdir, "raw"), exist_ok=True)
+    # os.makedirs(os.path.join(args.outdir, "raw"), exist_ok=True)
 
-    #Make a bedgraph per gene
+    # Make a bedgraph per gene
     skipped = []
     for idx, gene in genes.iterrows():
         if gene.chr not in hic_data.chromosomes():
-            print("No HiC data for {} on {}".format(gene['name'], gene.chr))
+            print("No HiC data for {} on {}".format(gene["name"], gene.chr))
             continue
-        filename = os.path.join(args.outdir,
-                        "{}_{}_{}.bg.gz".format(gene['name'] or "UNK", gene.chr, int(gene.tss)))
+        filename = os.path.join(
+            args.outdir,
+            "{}_{}_{}.bg.gz".format(gene["name"] or "UNK", gene.chr, int(gene.tss)),
+        )
 
         if not args.overwrite:
             if os.path.exists(filename):
-                skipped.append(gene['name'])
-                print("Skipping {} on {} with tss {} since it already has hic data and --overwrite flag is not set".format(gene['name'], gene.chr, gene.tss))
+                skipped.append(gene["name"])
+                print(
+                    "Skipping {} on {} with tss {} since it already has hic data and --overwrite flag is not set".format(
+                        gene["name"], gene.chr, gene.tss
+                    )
+                )
                 continue
 
         hic_row = hic_data.row(gene.chr, gene.tss)
 
-        #Include all values within args.window of the tss. This will facilitate interpolating NaNs
-        values = [(gene.chr, idx * args.resolution,
-               (idx + 1) * args.resolution,
-               hic_row[0, idx]) for idx in range(hic_row.A.shape[1]) if abs(idx * args.resolution - int(gene.tss)) < args.window]
+        # Include all values within args.window of the tss. This will facilitate interpolating NaNs
+        values = [
+            (
+                gene.chr,
+                idx * args.resolution,
+                (idx + 1) * args.resolution,
+                hic_row[0, idx],
+            )
+            for idx in range(hic_row.A.shape[1])
+            if abs(idx * args.resolution - int(gene.tss)) < args.window
+        ]
 
-        #interpolate the nan's. Sometimes there may be nan's at the beginning/end of the vector - set to 0
-        #note this is only interpreting the nan's: missing data due to low kr norm value. This is not interpolating 0's in HiC
+        # interpolate the nan's. Sometimes there may be nan's at the beginning/end of the vector - set to 0
+        # note this is only interpreting the nan's: missing data due to low kr norm value. This is not interpolating 0's in HiC
         df2 = pandas.DataFrame.from_records(values).interpolate().fillna(value=0)
-        df2.to_csv(filename,
-              sep='\t', compression='gzip',
-              header=False, index=False)
+        df2.to_csv(filename, sep="\t", compression="gzip", header=False, index=False)
 
-        print("Completed {} on {}".format(gene['name'], gene.chr))
+        print("Completed {} on {}".format(gene["name"], gene.chr))
 
     if len(skipped) > 0:
-        print("Skipped {} genes because they already have HiC files".format(len(skipped)))
+        print(
+            "Skipped {} genes because they already have HiC files".format(len(skipped))
+        )

--- a/workflow/scripts/metrics.py
+++ b/workflow/scripts/metrics.py
@@ -1,9 +1,17 @@
-import os,sys
+import os, sys
 import pandas as pd
 import seaborn as sns
 import glob
 import numpy as np
-from subprocess import check_call, check_output, PIPE, Popen, getoutput, CalledProcessError
+from subprocess import (
+    check_call,
+    check_output,
+    PIPE,
+    Popen,
+    getoutput,
+    CalledProcessError,
+)
+
 
 def grabStatistics(arr_values):
     mean = arr_values.mean()
@@ -11,92 +19,118 @@ def grabStatistics(arr_values):
     std = arr_values.std()
     return mean, median, std
 
+
 # Generates QC Prediction Metrics:
 def GrabQCMetrics(prediction_df, outdir):
-    EnhancerPerGene = prediction_df.groupby(['TargetGene']).size()
-    EnhancerPerGene.to_csv(os.path.join(outdir,"EnhancerPerGene.txt"), sep="\t")
+    EnhancerPerGene = prediction_df.groupby(["TargetGene"]).size()
+    EnhancerPerGene.to_csv(os.path.join(outdir, "EnhancerPerGene.txt"), sep="\t")
 
     # Grab Number of Enhancers Per Gene
     GeneMean, GeneMedian, GeneStdev = grabStatistics(EnhancerPerGene)
 
     # Grab Number of genes per enhancers
-    NumGenesPerEnhancer = prediction_df[['chr', 'start', 'end']].groupby(['chr', 'start', 'end']).size()
-    NumGenesPerEnhancer.to_csv(os.path.join(outdir,"GenesPerEnhancer.txt"), sep="\t")
-    mean_genes_per_enhancer, median_genes_per_enhancer,stdev_genes_per_enhancer = grabStatistics(NumGenesPerEnhancer) 
+    NumGenesPerEnhancer = (
+        prediction_df[["chr", "start", "end"]].groupby(["chr", "start", "end"]).size()
+    )
+    NumGenesPerEnhancer.to_csv(os.path.join(outdir, "GenesPerEnhancer.txt"), sep="\t")
+    (
+        mean_genes_per_enhancer,
+        median_genes_per_enhancer,
+        stdev_genes_per_enhancer,
+    ) = grabStatistics(NumGenesPerEnhancer)
 
     # Grab Number of Enhancer-Gene Pairs Per Chromsome
-    enhancergeneperchrom = prediction_df.groupby(['chr']).size()
-    enhancergeneperchrom.to_csv(os.path.join(outdir, "EnhancerGenePairsPerChrom.txt"), sep="\t")
-    
-    mean_enhancergeneperchrom, median_enhancergeneperchrom ,stdev_enhancergeneperchrom = grabStatistics(enhancergeneperchrom) 
+    enhancergeneperchrom = prediction_df.groupby(["chr"]).size()
+    enhancergeneperchrom.to_csv(
+        os.path.join(outdir, "EnhancerGenePairsPerChrom.txt"), sep="\t"
+    )
+
+    (
+        mean_enhancergeneperchrom,
+        median_enhancergeneperchrom,
+        stdev_enhancergeneperchrom,
+    ) = grabStatistics(enhancergeneperchrom)
 
     # Enhancer-Gene Distancee
-    distance = np.array(prediction_df['distance'])
+    distance = np.array(prediction_df["distance"])
     thquantile = np.percentile(distance, 10)
     testthquantile = np.percentile(distance, 90)
 
     # Number of Enhancers
-    numEnhancers = len(prediction_df[['chr', 'start', 'end']].drop_duplicates())
-    
+    numEnhancers = len(prediction_df[["chr", "start", "end"]].drop_duplicates())
+
     # Plot Distributions and save as png
     PlotDistribution(NumGenesPerEnhancer, "NumberOfGenesPerEnhancer", outdir)
     PlotDistribution(EnhancerPerGene, "NumberOfEnhancersPerGene", outdir)
     PlotDistribution(enhancergeneperchrom, "EnhancersPerChromosome", outdir)
     PlotDistribution(distance, "EnhancerGeneDistance", outdir)
 
-    pred_metrics={}
-    pred_metrics['MedianEnhPerGene'] = GeneMedian
-    pred_metrics['StdEnhPerGene'] = GeneStdev
-    pred_metrics['MedianGenePerEnh'] = median_genes_per_enhancer
-    pred_metrics['StdGenePerEnh'] = stdev_genes_per_enhancer
-    pred_metrics['MeanEnhPerGene'] = GeneMean
-    pred_metrics['MeanGenePerEnh'] = mean_genes_per_enhancer
-    pred_metrics['MedianEGDist'] = np.median(distance)
-    pred_metrics['MeanEGDist'] = np.mean(distance)
-    pred_metrics['StdEGDist'] = np.std(distance)
-    pred_metrics['NumEnhancersPerChrom'] = median_enhancergeneperchrom
-    pred_metrics['MeanEnhancersPerChrom'] = mean_enhancergeneperchrom
-    pred_metrics['NumEnhancers'] = numEnhancers
-    pred_metrics['EG10th'] = thquantile
-    pred_metrics['EG90th'] = testthquantile
+    pred_metrics = {}
+    pred_metrics["MedianEnhPerGene"] = GeneMedian
+    pred_metrics["StdEnhPerGene"] = GeneStdev
+    pred_metrics["MedianGenePerEnh"] = median_genes_per_enhancer
+    pred_metrics["StdGenePerEnh"] = stdev_genes_per_enhancer
+    pred_metrics["MeanEnhPerGene"] = GeneMean
+    pred_metrics["MeanGenePerEnh"] = mean_genes_per_enhancer
+    pred_metrics["MedianEGDist"] = np.median(distance)
+    pred_metrics["MeanEGDist"] = np.mean(distance)
+    pred_metrics["StdEGDist"] = np.std(distance)
+    pred_metrics["NumEnhancersPerChrom"] = median_enhancergeneperchrom
+    pred_metrics["MeanEnhancersPerChrom"] = mean_enhancergeneperchrom
+    pred_metrics["NumEnhancers"] = numEnhancers
+    pred_metrics["EG10th"] = thquantile
+    pred_metrics["EG90th"] = testthquantile
     return pred_metrics
+
 
 def PlotQuantilePlot(EnhancerList, title, outdir):
-    i='DHS'
-    ax = sns.scatterplot('DHS.RPM', 'DHS.RPM.quantile', data=EnhancerList)
+    i = "DHS"
+    ax = sns.scatterplot("DHS.RPM", "DHS.RPM.quantile", data=EnhancerList)
     ax.set_title(title)
-    ax.set_ylabel('RPM.quantile')
-    ax.set_xlabel('RPM')
+    ax.set_ylabel("RPM.quantile")
+    ax.set_xlabel("RPM")
     fig = ax.get_figure()
-    outfile = os.path.join(outdir, i+str(title)+".pdf")
-    fig.savefig(outfile, format='pdf')
-    
-    i="H3K27ac"
-    ax = sns.scatterplot('H3K27ac.RPM', 'H3K27ac.RPM.quantile', data=EnhancerList)
+    outfile = os.path.join(outdir, i + str(title) + ".pdf")
+    fig.savefig(outfile, format="pdf")
+
+    i = "H3K27ac"
+    ax = sns.scatterplot("H3K27ac.RPM", "H3K27ac.RPM.quantile", data=EnhancerList)
     ax.set_title(title)
-    ax.set_ylabel('RPM.quantile')
-    ax.set_xlabel('RPM')
+    ax.set_ylabel("RPM.quantile")
+    ax.set_xlabel("RPM")
     fig = ax.get_figure()
-    outfile = os.path.join(outdir, i+str(title)+".pdf")
-    fig.savefig(outfile, format='pdf')
+    outfile = os.path.join(outdir, i + str(title) + ".pdf")
+    fig.savefig(outfile, format="pdf")
+
 
 def NeighborhoodFileQC(pred_metrics, neighborhood_dir, outdir, feature):
-    x = glob.glob(os.path.join(neighborhood_dir, "Enhancers.{}.*CountReads.bedgraph".format(feature)))
-    y = glob.glob(os.path.join(neighborhood_dir, "Genes.TSS1kb.{}.*CountReads.bedgraph".format(feature)))
-    z = glob.glob(os.path.join(neighborhood_dir, "Genes.{}.*CountReads.bedgraph".format(feature)))
-    
-    data = pd.read_csv(x[0],sep="\t", header=None)
-    data1 = pd.read_csv(y[0],sep="\t", header=None)
-    data2 = pd.read_csv(z[0],sep="\t", header=None)
+    x = glob.glob(
+        os.path.join(
+            neighborhood_dir, "Enhancers.{}.*CountReads.bedgraph".format(feature)
+        )
+    )
+    y = glob.glob(
+        os.path.join(
+            neighborhood_dir, "Genes.TSS1kb.{}.*CountReads.bedgraph".format(feature)
+        )
+    )
+    z = glob.glob(
+        os.path.join(neighborhood_dir, "Genes.{}.*CountReads.bedgraph".format(feature))
+    )
+
+    data = pd.read_csv(x[0], sep="\t", header=None)
+    data1 = pd.read_csv(y[0], sep="\t", header=None)
+    data2 = pd.read_csv(z[0], sep="\t", header=None)
 
     counts = data.iloc[:, 3].sum()
-    counts2 = data1.iloc[:,3].sum()
-    counts3 = data2.iloc[:,3].sum()
-   
-    pred_metrics['countsEnhancers_{}'.format(feature)] = counts
-    pred_metrics['countsGeneTSS_{}'.format(feature)] = counts2
-    pred_metrics['countsGenes_{}'.format(feature)] = counts3
+    counts2 = data1.iloc[:, 3].sum()
+    counts3 = data2.iloc[:, 3].sum()
+
+    pred_metrics["countsEnhancers_{}".format(feature)] = counts
+    pred_metrics["countsGeneTSS_{}".format(feature)] = counts2
+    pred_metrics["countsGenes_{}".format(feature)] = counts3
     return pred_metrics
+
 
 # Generates peak file metrics
 def PeakFileQC(pred_metrics, macs_peaks, outdir):
@@ -105,35 +139,35 @@ def PeakFileQC(pred_metrics, macs_peaks, outdir):
     else:
         peaks = pd.read_csv(macs_peaks, sep="\t", header=None)
 
-    # Calculate metrics for candidate regions 
-    #outfile = os.path.join(outdir, os.path.basename(macs_peaks) + ".sorted.candidateRegions.bed")
-    
-    candidateRegions = pd.read_csv(macs_peaks, sep="\t", header=None)
-    candidateRegions['dist'] = candidateRegions[2] - candidateRegions[1]
-    candreg = list(candidateRegions['dist'])
-    PlotDistribution(candreg, 'WidthOfCandidateRegions', outdir)
-    
+    # Calculate metrics for candidate regions
+    # outfile = os.path.join(outdir, os.path.basename(macs_peaks) + ".sorted.candidateRegions.bed")
 
-    # Calculate width of peaks 
-    peaks['dist'] = peaks[2]-peaks[1]
-    peaks_array = list(peaks['dist'])
-    pred_metrics['NumPeaks'] = len(peaks['dist'])
-    pred_metrics['MedWidth'] = peaks['dist'].median()
-    pred_metrics['MeanWidth'] = peaks['dist'].mean()
-    pred_metrics['StdWidth'] = peaks['dist'].std()
-    pred_metrics['NumCandidate'] = len(candidateRegions['dist'])
-    pred_metrics['MedWidthCandidate'] = candidateRegions['dist'].median()
-    pred_metrics['MeanWidthCandidate'] = candidateRegions['dist'].mean()
-    pred_metrics['StdWidthCandidate'] = candidateRegions['dist'].std()
+    candidateRegions = pd.read_csv(macs_peaks, sep="\t", header=None)
+    candidateRegions["dist"] = candidateRegions[2] - candidateRegions[1]
+    candreg = list(candidateRegions["dist"])
+    PlotDistribution(candreg, "WidthOfCandidateRegions", outdir)
+
+    # Calculate width of peaks
+    peaks["dist"] = peaks[2] - peaks[1]
+    peaks_array = list(peaks["dist"])
+    pred_metrics["NumPeaks"] = len(peaks["dist"])
+    pred_metrics["MedWidth"] = peaks["dist"].median()
+    pred_metrics["MeanWidth"] = peaks["dist"].mean()
+    pred_metrics["StdWidth"] = peaks["dist"].std()
+    pred_metrics["NumCandidate"] = len(candidateRegions["dist"])
+    pred_metrics["MedWidthCandidate"] = candidateRegions["dist"].median()
+    pred_metrics["MeanWidthCandidate"] = candidateRegions["dist"].mean()
+    pred_metrics["StdWidthCandidate"] = candidateRegions["dist"].std()
 
     return pred_metrics
+
 
 # Plots and saves a distribution as *.png
 def PlotDistribution(array, title, outdir):
     ax = sns.distplot(array)
     ax.set_title(title)
-    ax.set_ylabel('Estimated PDF of distribution')
-    ax.set_xlabel('Counts')
+    ax.set_ylabel("Estimated PDF of distribution")
+    ax.set_xlabel("Counts")
     fig = ax.get_figure()
-    outfile = os.path.join(outdir, str(title)+".pdf")
-    fig.savefig(outfile, format='pdf')
+    outfile = os.path.join(outdir, str(title) + ".pdf")
+    fig.savefig(outfile, format="pdf")

--- a/workflow/scripts/neighborhoods.py
+++ b/workflow/scripts/neighborhoods.py
@@ -1,33 +1,46 @@
-import pandas as pd
-import numpy as np
-from scipy import interpolate
-import pysam
+import linecache
 import os
 import os.path
-from subprocess import check_call, check_output, PIPE, Popen, getoutput, CalledProcessError
-from tools import *
-import linecache
-import traceback
 import time
+import traceback
+from subprocess import (
+    PIPE,
+    CalledProcessError,
+    Popen,
+    check_call,
+    check_output,
+    getoutput,
+)
+
+import numpy as np
+import pandas as pd
 import pyranges as pr
+import pysam
+from scipy import interpolate
+from tools import *
 
-pd.options.display.max_colwidth = 10000 #seems to be necessary for pandas to read long file names... strange
+pd.options.display.max_colwidth = (
+    10000  # seems to be necessary for pandas to read long file names... strange
+)
 
-def load_genes(file,
-               ue_file,
-               chrom_sizes,
-               outdir,
-               expression_table_list,
-               gene_id_names,
-               primary_id,
-               cellType,
-               class_gene_file):
 
-    bed = read_bed(file) 
+def load_genes(
+    file,
+    ue_file,
+    chrom_sizes,
+    outdir,
+    expression_table_list,
+    gene_id_names,
+    primary_id,
+    cellType,
+    class_gene_file,
+):
+    bed = read_bed(file)
     genes = process_gene_bed(bed, gene_id_names, primary_id, chrom_sizes)
 
-    genes[['chr', 'start', 'end', 'name', 'score', 'strand']].to_csv(os.path.join(outdir, "GeneList.bed"),
-                                                                    sep='\t', index=False, header=False)
+    genes[["chr", "start", "end", "name", "score", "strand"]].to_csv(
+        os.path.join(outdir, "GeneList.bed"), sep="\t", index=False, header=False
+    )
 
     if len(expression_table_list) > 0:
         # Add expression information
@@ -37,90 +50,135 @@ def load_genes(file,
         for expression_table in expression_table_list:
             try:
                 name = os.path.basename(expression_table)
-                expr = pd.read_table(expression_table, names=[primary_id, name + '.Expression'])
-                expr[name + '.Expression'] = expr[name + '.Expression'].astype(float)
+                expr = pd.read_table(
+                    expression_table, names=[primary_id, name + ".Expression"]
+                )
+                expr[name + ".Expression"] = expr[name + ".Expression"].astype(float)
                 expr = expr.groupby(primary_id).max()
 
-                genes = genes.merge(expr, how="left", right_index=True, left_on='symbol')
-                names_list.append(name + '.Expression')
+                genes = genes.merge(
+                    expr, how="left", right_index=True, left_on="symbol"
+                )
+                names_list.append(name + ".Expression")
             except Exception as e:
                 print(e)
                 traceback.print_exc()
                 print("Failed on {}".format(expression_table))
 
-        genes['Expression'] = genes[names_list].mean(axis = 1)
-        genes['Expression.quantile'] = genes['Expression'].rank(method='average', na_option="top", ascending=True, pct=True)
+        genes["Expression"] = genes[names_list].mean(axis=1)
+        genes["Expression.quantile"] = genes["Expression"].rank(
+            method="average", na_option="top", ascending=True, pct=True
+        )
     else:
-        genes['Expression'] = np.NaN
-    
-    #Ubiquitously expressed annotation
+        genes["Expression"] = np.NaN
+
+    # Ubiquitously expressed annotation
     if ue_file is not None:
         ubiq = pd.read_csv(ue_file, sep="\t")
-        genes['is_ue'] = genes['name'].isin(ubiq.iloc[:,0].values.tolist())
+        genes["is_ue"] = genes["name"].isin(ubiq.iloc[:, 0].values.tolist())
 
-    #cell type
-    genes['cellType'] = cellType
+    # cell type
+    genes["cellType"] = cellType
 
-    #genes for class assignment
+    # genes for class assignment
     if class_gene_file is None:
         genes_for_class_assignment = genes
     else:
         genes_for_class_assignment = read_bed(class_gene_file)
-        genes_for_class_assignment = process_gene_bed(genes_for_class_assignment, gene_id_names, primary_id, chrom_sizes, fail_on_nonunique=False)
+        genes_for_class_assignment = process_gene_bed(
+            genes_for_class_assignment,
+            gene_id_names,
+            primary_id,
+            chrom_sizes,
+            fail_on_nonunique=False,
+        )
 
     return genes, genes_for_class_assignment
 
 
-def annotate_genes_with_features(genes, 
-           genome_sizes,
-           skip_gene_counts=False,
-           features={},
-           outdir=".",
-           force=False,
-           use_fast_count=True,
-           default_accessibility_feature = "",
-           **kwargs):
-
-    #Setup files for counting
+def annotate_genes_with_features(
+    genes,
+    genome_sizes,
+    skip_gene_counts=False,
+    features={},
+    outdir=".",
+    force=False,
+    use_fast_count=True,
+    default_accessibility_feature="",
+    **kwargs
+):
+    # Setup files for counting
     bounds_bed = os.path.join(outdir, "GeneList.bed")
     tss1kb = make_tss_region_file(genes, outdir, genome_sizes)
     tss1kb_file = os.path.join(outdir, "GeneList.TSS1kb.bed")
 
-    #Count features over genes and promoters
-    genes = count_features_for_bed(genes, bounds_bed, genome_sizes, features, outdir, "Genes", force=force, use_fast_count=use_fast_count)
-    tsscounts = count_features_for_bed(tss1kb, tss1kb_file, genome_sizes, features, outdir, "Genes.TSS1kb", force=force, use_fast_count=use_fast_count)
-    tsscounts = tsscounts.drop(['chr','start','end','score','strand'], axis=1)
+    # Count features over genes and promoters
+    genes = count_features_for_bed(
+        genes,
+        bounds_bed,
+        genome_sizes,
+        features,
+        outdir,
+        "Genes",
+        force=force,
+        use_fast_count=use_fast_count,
+    )
+    tsscounts = count_features_for_bed(
+        tss1kb,
+        tss1kb_file,
+        genome_sizes,
+        features,
+        outdir,
+        "Genes.TSS1kb",
+        force=force,
+        use_fast_count=use_fast_count,
+    )
+    tsscounts = tsscounts.drop(["chr", "start", "end", "score", "strand"], axis=1)
 
-    merged = genes.merge(tsscounts, on="name", suffixes=['','.TSS1Kb'])
+    merged = genes.merge(tsscounts, on="name", suffixes=["", ".TSS1Kb"])
 
-    access_col = default_accessibility_feature + ".RPKM.quantile.TSS1Kb"  
+    access_col = default_accessibility_feature + ".RPKM.quantile.TSS1Kb"
 
-    if 'H3K27ac.RPKM.quantile.TSS1Kb' in merged.columns:
-        merged['PromoterActivityQuantile'] = ((0.0001+merged['H3K27ac.RPKM.quantile.TSS1Kb'])*(0.0001+merged[access_col])).rank(method='average', na_option="top", ascending=True, pct=True)
+    if "H3K27ac.RPKM.quantile.TSS1Kb" in merged.columns:
+        merged["PromoterActivityQuantile"] = (
+            (0.0001 + merged["H3K27ac.RPKM.quantile.TSS1Kb"])
+            * (0.0001 + merged[access_col])
+        ).rank(method="average", na_option="top", ascending=True, pct=True)
     else:
-        merged['PromoterActivityQuantile'] = ((0.0001+merged[access_col])).rank(method='average', na_option="top", ascending=True, pct=True)
+        merged["PromoterActivityQuantile"] = ((0.0001 + merged[access_col])).rank(
+            method="average", na_option="top", ascending=True, pct=True
+        )
 
-
-    merged.to_csv(os.path.join(outdir, "GeneList.txt"),
-             sep='\t', index=False, header=True, float_format="%.6f")
+    merged.to_csv(
+        os.path.join(outdir, "GeneList.txt"),
+        sep="\t",
+        index=False,
+        header=True,
+        float_format="%.6f",
+    )
 
     return merged
 
+
 def make_tss_region_file(genes, outdir, sizes, tss_slop=500):
-    #Given a gene file, define 1kb regions around the tss of each gene
+    # Given a gene file, define 1kb regions around the tss of each gene
 
-    sizes_pr = df_to_pyranges(read_bed(sizes + '.bed'))
-    tss1kb = genes.loc[:,['chr','start','end','name','score','strand']]
-    tss1kb['start'] = genes['tss']
-    tss1kb['end'] = genes['tss']
+    sizes_pr = df_to_pyranges(read_bed(sizes + ".bed"))
+    tss1kb = genes.loc[:, ["chr", "start", "end", "name", "score", "strand"]]
+    tss1kb["start"] = genes["tss"]
+    tss1kb["end"] = genes["tss"]
     tss1kb = df_to_pyranges(tss1kb).slack(tss_slop)
-    tss1kb = pr.gf.genome_bounds(tss1kb, sizes_pr).df[['Chromosome','Start','End','name','score','strand']]
-    tss1kb.columns = ['chr','start','end','name','score','strand']
+    tss1kb = pr.gf.genome_bounds(tss1kb, sizes_pr).df[
+        ["Chromosome", "Start", "End", "name", "score", "strand"]
+    ]
+    tss1kb.columns = ["chr", "start", "end", "name", "score", "strand"]
     tss1kb_file = os.path.join(outdir, "GeneList.TSS1kb.bed")
-    tss1kb.to_csv(tss1kb_file, header=False, index=False, sep='\t')
+    tss1kb.to_csv(tss1kb_file, header=False, index=False, sep="\t")
 
-    #The TSS1kb file should be sorted
-    sort_command = "bedtools sort -faidx {sizes} -i {tss1kb_file} > {tss1kb_file}.sorted; mv {tss1kb_file}.sorted {tss1kb_file}".format(**locals())
+    # The TSS1kb file should be sorted
+    sort_command = "bedtools sort -faidx {sizes} -i {tss1kb_file} > {tss1kb_file}.sorted; mv {tss1kb_file}.sorted {tss1kb_file}".format(
+        **locals()
+    )
     run_command(sort_command)
 
     # p = Popen(sort_command, stdout=PIPE, stderr=PIPE, shell=True)
@@ -128,113 +186,163 @@ def make_tss_region_file(genes, outdir, sizes, tss_slop=500):
     # (stdoutdata, stderrdata) = p.communicate()
     # err = str(stderrdata, 'utf-8')
 
-    return(tss1kb)
+    return tss1kb
 
-def process_gene_bed(bed, name_cols, main_name, chrom_sizes=None, fail_on_nonunique=True):
 
+def process_gene_bed(
+    bed, name_cols, main_name, chrom_sizes=None, fail_on_nonunique=True
+):
     try:
-        bed = bed.drop(['thickStart','thickEnd','itemRgb','blockCount','blockSizes','blockStarts'], axis=1)
+        bed = bed.drop(
+            [
+                "thickStart",
+                "thickEnd",
+                "itemRgb",
+                "blockCount",
+                "blockSizes",
+                "blockStarts",
+            ],
+            axis=1,
+        )
     except Exception as e:
         pass
-    
-    assert(main_name in name_cols)
+
+    assert main_name in name_cols
 
     names = bed.name.str.split(";", expand=True)
-    assert(len(names.columns) == len(name_cols.split(",")))
+    assert len(names.columns) == len(name_cols.split(","))
     names.columns = name_cols.split(",")
     bed = pd.concat([bed, names], axis=1)
 
-    bed['name'] = bed[main_name]
-    #bed = bed.sort_values(by=['chr','start']) #JN Keep original sort order
+    bed["name"] = bed[main_name]
+    # bed = bed.sort_values(by=['chr','start']) #JN Keep original sort order
 
-    bed['tss'] = get_tss_for_bed(bed)
+    bed["tss"] = get_tss_for_bed(bed)
 
     bed.drop_duplicates(inplace=True)
 
-    #Remove genes that are not defined in chromosomes file
+    # Remove genes that are not defined in chromosomes file
     if chrom_sizes is not None:
         sizes = read_bed(chrom_sizes)
-        bed['chr'] = bed['chr'].astype('str') #JN needed in case chromosomes are all integer
-        bed = bed[bed['chr'].isin(set(sizes['chr'].values))]
+        bed["chr"] = bed["chr"].astype(
+            "str"
+        )  # JN needed in case chromosomes are all integer
+        bed = bed[bed["chr"].isin(set(sizes["chr"].values))]
 
-    #Enforce that gene names should be unique
+    # Enforce that gene names should be unique
     if fail_on_nonunique:
-        assert(len(set(bed['name'])) == len(bed['name'])), "Gene IDs are not unique! Failing. Please ensure unique identifiers are passed to --genes"
+        assert len(set(bed["name"])) == len(
+            bed["name"]
+        ), "Gene IDs are not unique! Failing. Please ensure unique identifiers are passed to --genes"
 
     return bed
 
+
 def get_tss_for_bed(bed):
     assert_bed3(bed)
-    tss = bed['start'].copy()
-    tss.loc[bed.loc[:,'strand'] == "-"] = bed.loc[bed.loc[:,'strand'] == "-",'end']
+    tss = bed["start"].copy()
+    tss.loc[bed.loc[:, "strand"] == "-"] = bed.loc[bed.loc[:, "strand"] == "-", "end"]
 
     return tss
 
+
 def assert_bed3(df):
-    assert(type(df).__name__ == "DataFrame")
-    assert('chr' in df.columns)
-    assert('start' in df.columns)
-    assert('end' in df.columns)
-    assert('strand' in df.columns)
+    assert type(df).__name__ == "DataFrame"
+    assert "chr" in df.columns
+    assert "start" in df.columns
+    assert "end" in df.columns
+    assert "strand" in df.columns
 
-def load_enhancers(outdir=".",
-                   genome_sizes="",
-                   features={},
-                   genes=None,
-                   force=False,
-                   candidate_peaks="",
-                   skip_rpkm_quantile=False,
-                   cellType=None,
-                   tss_slop_for_class_assignment = 500,
-                   use_fast_count=True,
-                   default_accessibility_feature = "",
-                   qnorm = None,
-                   class_override_file = None):
 
+def load_enhancers(
+    outdir=".",
+    genome_sizes="",
+    features={},
+    genes=None,
+    force=False,
+    candidate_peaks="",
+    skip_rpkm_quantile=False,
+    cellType=None,
+    tss_slop_for_class_assignment=500,
+    use_fast_count=True,
+    default_accessibility_feature="",
+    qnorm=None,
+    class_override_file=None,
+):
     enhancers = read_bed(candidate_peaks)
-    enhancers['chr'] = enhancers['chr'].astype('str')
+    enhancers["chr"] = enhancers["chr"].astype("str")
 
+    enhancers = count_features_for_bed(
+        enhancers,
+        candidate_peaks,
+        genome_sizes,
+        features,
+        outdir,
+        "Enhancers",
+        skip_rpkm_quantile,
+        force,
+        use_fast_count,
+    )
 
-    enhancers = count_features_for_bed(enhancers, candidate_peaks, genome_sizes, features, outdir, "Enhancers", skip_rpkm_quantile, force, use_fast_count)
-
-    #cellType
+    # cellType
     if cellType is not None:
-        enhancers['cellType'] = cellType
+        enhancers["cellType"] = cellType
 
     # Assign categories
     if genes is not None:
         print("Assigning classes to enhancers")
-        enhancers = assign_enhancer_classes(enhancers, genes, tss_slop = tss_slop_for_class_assignment)
+        enhancers = assign_enhancer_classes(
+            enhancers, genes, tss_slop=tss_slop_for_class_assignment
+        )
 
-    #TO DO: Should qnorm each bam file separately (before averaging). Currently qnorm being performed on the average
+    # TO DO: Should qnorm each bam file separately (before averaging). Currently qnorm being performed on the average
     enhancers = run_qnorm(enhancers, qnorm)
     enhancers = compute_activity(enhancers, default_accessibility_feature)
 
-    enhancers.to_csv(os.path.join(outdir, "EnhancerList.txt"),
-                sep='\t', index=False, header=True, float_format="%.6f")
-    enhancers[['chr', 'start', 'end', 'name']].to_csv(os.path.join(outdir, "EnhancerList.bed"),
-                sep='\t', index=False, header=False)
+    enhancers.to_csv(
+        os.path.join(outdir, "EnhancerList.txt"),
+        sep="\t",
+        index=False,
+        header=True,
+        float_format="%.6f",
+    )
+    enhancers[["chr", "start", "end", "name"]].to_csv(
+        os.path.join(outdir, "EnhancerList.bed"), sep="\t", index=False, header=False
+    )
 
-#Kristy's version
+
+# Kristy's version
 def assign_enhancer_classes(enhancers, genes, tss_slop=500):
-
-    # build pyranges df 
-    tss_pyranges = df_to_pyranges(genes, start_col='tss', end_col='tss', start_slop=tss_slop, end_slop=tss_slop)
+    # build pyranges df
+    tss_pyranges = df_to_pyranges(
+        genes, start_col="tss", end_col="tss", start_slop=tss_slop, end_slop=tss_slop
+    )
     gene_pyranges = df_to_pyranges(genes)
 
-    def get_class_pyranges(enhancers, tss_pyranges = tss_pyranges, gene_pyranges = gene_pyranges): 
-        '''
+    def get_class_pyranges(
+        enhancers, tss_pyranges=tss_pyranges, gene_pyranges=gene_pyranges
+    ):
+        """
         Takes in PyRanges objects : Enhancers, tss_pyranges, gene_pyranges
-        Returns dataframe with  uid (representing enhancer) and symbol of the gene/promoter that is overlapped'''
+        Returns dataframe with  uid (representing enhancer) and symbol of the gene/promoter that is overlapped
+        """
 
-        #genes
+        # genes
         genic_enh = enhancers.join(gene_pyranges, suffix="_genic")
-        genic_enh = genic_enh.df[['symbol','uid']].groupby('uid',as_index=False).aggregate(lambda x: ','.join(list(set(x))))
-        
-        #promoters
+        genic_enh = (
+            genic_enh.df[["symbol", "uid"]]
+            .groupby("uid", as_index=False)
+            .aggregate(lambda x: ",".join(list(set(x))))
+        )
+
+        # promoters
         promoter_enh = enhancers.join(tss_pyranges, suffix="_promoter")
-        promoter_enh = promoter_enh.df[['symbol','uid']].groupby('uid',as_index=False).aggregate(lambda x: ','.join(list(set(x))))
-        
+        promoter_enh = (
+            promoter_enh.df[["symbol", "uid"]]
+            .groupby("uid", as_index=False)
+            .aggregate(lambda x: ",".join(list(set(x))))
+        )
+
         return genic_enh, promoter_enh
 
     # import pdb
@@ -243,34 +351,41 @@ def assign_enhancer_classes(enhancers, genes, tss_slop=500):
 
     # label everything as intergenic
     enhancers["class"] = "intergenic"
-    enhancers['uid'] = range(enhancers.shape[0])
+    enhancers["uid"] = range(enhancers.shape[0])
     enh = df_to_pyranges(enhancers)
- 
+
     genes, promoters = get_class_pyranges(enh)
-    enhancers = enh.df.drop(['Chromosome','Start','End'], axis=1)
-    enhancers.loc[enhancers['uid'].isin(genes.uid), 'class'] = 'genic'
-    enhancers.loc[enhancers['uid'].isin(promoters.uid), 'class'] = 'promoter' 
-    
+    enhancers = enh.df.drop(["Chromosome", "Start", "End"], axis=1)
+    enhancers.loc[enhancers["uid"].isin(genes.uid), "class"] = "genic"
+    enhancers.loc[enhancers["uid"].isin(promoters.uid), "class"] = "promoter"
+
     enhancers["isPromoterElement"] = enhancers["class"] == "promoter"
     enhancers["isGenicElement"] = enhancers["class"] == "genic"
     enhancers["isIntergenicElement"] = enhancers["class"] == "intergenic"
-  
+
     # Output stats
     print("Total enhancers: {}".format(len(enhancers)))
-    print("         Promoters: {}".format(sum(enhancers['isPromoterElement'])))
-    print("         Genic: {}".format(sum(enhancers['isGenicElement'])))
-    print("         Intergenic: {}".format(sum(enhancers['isIntergenicElement'])))
+    print("         Promoters: {}".format(sum(enhancers["isPromoterElement"])))
+    print("         Genic: {}".format(sum(enhancers["isGenicElement"])))
+    print("         Intergenic: {}".format(sum(enhancers["isIntergenicElement"])))
 
-    #Add promoter/genic symbol
-    enhancers = enhancers.merge(promoters.rename(columns={'symbol':'promoterSymbol'}), on='uid', how = 'left').fillna(value={'promoterSymbol':""})
-    enhancers = enhancers.merge(genes.rename(columns={'symbol':'genicSymbol'}), on='uid', how = 'left').fillna(value={'genicSymbol':""})
-    enhancers.drop(['uid'], axis=1, inplace=True)
+    # Add promoter/genic symbol
+    enhancers = enhancers.merge(
+        promoters.rename(columns={"symbol": "promoterSymbol"}), on="uid", how="left"
+    ).fillna(value={"promoterSymbol": ""})
+    enhancers = enhancers.merge(
+        genes.rename(columns={"symbol": "genicSymbol"}), on="uid", how="left"
+    ).fillna(value={"genicSymbol": ""})
+    enhancers.drop(["uid"], axis=1, inplace=True)
 
-    # just to keep things consistent with original code 
-    enhancers["name"] = enhancers.apply(lambda e: "{}|{}:{}-{}".format(e["class"], e.chr, e.start, e.end), axis=1)
+    # just to keep things consistent with original code
+    enhancers["name"] = enhancers.apply(
+        lambda e: "{}|{}:{}-{}".format(e["class"], e.chr, e.start, e.end), axis=1
+    )
     return enhancers
 
-#TO DO: convert to pyranges
+
+# TO DO: convert to pyranges
 # def overrideEnhancerAnnotations(enhancers, cell_line, override_file):
 #     #Override enhancer class with manual annotations
 
@@ -298,36 +413,53 @@ def assign_enhancer_classes(enhancers, genes, tss_slop=500):
 
 #     return enhancers.ranges
 
+
 def run_count_reads(target, output, bed_file, genome_sizes, use_fast_count):
     if target.endswith(".bam"):
-        count_bam(target, bed_file, output, genome_sizes=genome_sizes, use_fast_count=use_fast_count)
+        count_bam(
+            target,
+            bed_file,
+            output,
+            genome_sizes=genome_sizes,
+            use_fast_count=use_fast_count,
+        )
     elif target.endswith(".tagAlign.gz") or target.endswith(".tagAlign.bgz"):
         count_tagalign(target, bed_file, output, genome_sizes)
     elif isBigWigFile(target):
         count_bigwig(target, bed_file, output)
     else:
-        raise ValueError("File {} name was not in .bam, .tagAlign.gz, .bw".format(target))
+        raise ValueError(
+            "File {} name was not in .bam, .tagAlign.gz, .bw".format(target)
+        )
 
 
-def count_bam(bamfile, bed_file, output, genome_sizes, use_fast_count=True, verbose=True):
+def count_bam(
+    bamfile, bed_file, output, genome_sizes, use_fast_count=True, verbose=True
+):
     reads = pysam.AlignmentFile(bamfile)
     read_chrs = set(reads.references)
     bed_regions = pd.read_table(bed_file, header=None)
     bed_regions = bed_regions[bed_regions.columns[:3]]
     bed_regions.columns = "chr start end".split()
-    counts = [(reads.count(row.chr, row.start, row.end) if (row.chr in read_chrs) else 0) for _, row in bed_regions.iterrows()]
-    bed_regions['count'] = counts
+    counts = [
+        (reads.count(row.chr, row.start, row.end) if (row.chr in read_chrs) else 0)
+        for _, row in bed_regions.iterrows()
+    ]
+    bed_regions["count"] = counts
     bed_regions.to_csv(output, header=None, index=None, sep="\t")
+
 
 def count_tagalign(tagalign, bed_file, output, genome_sizes):
     # command1 = "tabix -B {tagalign} {bed_file} | cut -f1-3".format(**locals())
     index_file = tagalign + ".tbi"
     if os.path.exists(index_file):
-      command1 = ""
+        command1 = ""
     else:
-      command1 = "tabix -p bed {tagalign} | cut -f1-3".format(**locals())
+        command1 = "tabix -p bed {tagalign} | cut -f1-3".format(**locals())
     # command2 = "bedtools coverage -counts -b stdin -a {bed_file} | awk '{{print $1 \"\\t\" $2 \"\\t\" $3 \"\\t\" $NF}}' ".format(**locals())
-    command2 = "bedtools sort -faidx {genome_sizes} -i {tagalign} | bedtools coverage -counts -b stdin -a {bed_file} -sorted -g {genome_sizes} | awk '{{print $1 \"\\t\" $2 \"\\t\" $3 \"\\t\" $NF}}'".format(**locals())
+    command2 = 'bedtools sort -faidx {genome_sizes} -i {tagalign} | bedtools coverage -counts -b stdin -a {bed_file} -sorted -g {genome_sizes} | awk \'{{print $1 "\\t" $2 "\\t" $3 "\\t" $NF}}\''.format(
+        **locals()
+    )
     p1 = Popen(command1, stdout=PIPE, shell=True)
     with open(output, "wb") as outfp:
         p2 = check_call(command2, stdin=p1.stdout, stdout=outfp, shell=True)
@@ -335,8 +467,10 @@ def count_tagalign(tagalign, bed_file, output, genome_sizes):
     if not p2 == 0:
         print(p2.stderr)
 
+
 def count_bigwig(target, bed_file, output):
-    from pyBigWig import open as open_bigwig    
+    from pyBigWig import open as open_bigwig
+
     bw = open_bigwig(target)
     bed = read_bed(bed_file)
     with open(output, "wb") as outfp:
@@ -344,58 +478,113 @@ def count_bigwig(target, bed_file, output):
             # if isinstance(name, np.float):
             #     name = ""
             try:
-                val = bw.stats(chr, int(start), int(max(end, start + 1)), "mean")[0] or 0
+                val = (
+                    bw.stats(chr, int(start), int(max(end, start + 1)), "mean")[0] or 0
+                )
             except RuntimeError:
                 print("Failed on", chr, start, end)
                 raise
             val *= abs(end - start)  # convert to total coverage
-            output = ("\t".join([chr, str(start), str(end), str(val)]) + "\n").encode('ascii')
+            output = ("\t".join([chr, str(start), str(end), str(val)]) + "\n").encode(
+                "ascii"
+            )
             outfp.write(output)
 
 
 def isBigWigFile(filename):
-    return(filename.endswith(".bw") or filename.endswith(".bigWig") or filename.endswith(".bigwig"))
+    return (
+        filename.endswith(".bw")
+        or filename.endswith(".bigWig")
+        or filename.endswith(".bigwig")
+    )
 
-def count_features_for_bed(df, bed_file, genome_sizes, features, directory, filebase, skip_rpkm_quantile=False, force=False, use_fast_count=True):
 
+def count_features_for_bed(
+    df,
+    bed_file,
+    genome_sizes,
+    features,
+    directory,
+    filebase,
+    skip_rpkm_quantile=False,
+    force=False,
+    use_fast_count=True,
+):
     for feature, feature_bam_list in features.items():
         start_time = time.time()
-        if isinstance(feature_bam_list, str): 
+        if isinstance(feature_bam_list, str):
             feature_bam_list = [feature_bam_list]
 
         for feature_bam in feature_bam_list:
-            df = count_single_feature_for_bed(df, bed_file, genome_sizes, feature_bam, feature, directory, filebase, skip_rpkm_quantile, force, use_fast_count)
+            df = count_single_feature_for_bed(
+                df,
+                bed_file,
+                genome_sizes,
+                feature_bam,
+                feature,
+                directory,
+                filebase,
+                skip_rpkm_quantile,
+                force,
+                use_fast_count,
+            )
 
-        df = average_features(df, feature.replace('feature_',''), feature_bam_list, skip_rpkm_quantile)
+        df = average_features(
+            df, feature.replace("feature_", ""), feature_bam_list, skip_rpkm_quantile
+        )
         elapsed_time = time.time() - start_time
         print("Feature " + feature + " completed in " + str(elapsed_time))
 
     return df
 
-def count_single_feature_for_bed(df, bed_file, genome_sizes, feature_bam, feature, directory, filebase, skip_rpkm_quantile, force, use_fast_count):
+
+def count_single_feature_for_bed(
+    df,
+    bed_file,
+    genome_sizes,
+    feature_bam,
+    feature,
+    directory,
+    filebase,
+    skip_rpkm_quantile,
+    force,
+    use_fast_count,
+):
     orig_shape = df.shape[0]
     feature_name = feature + "." + os.path.basename(feature_bam)
-    feature_outfile = os.path.join(directory, "{}.{}.CountReads.bedgraph".format(filebase, feature_name))
+    feature_outfile = os.path.join(
+        directory, "{}.{}.CountReads.bedgraph".format(filebase, feature_name)
+    )
 
-    if force or (not os.path.exists(feature_outfile)) or (os.path.getsize(feature_outfile) == 0):
+    if (
+        force
+        or (not os.path.exists(feature_outfile))
+        or (os.path.getsize(feature_outfile) == 0)
+    ):
         print("Regenerating", feature_outfile)
         print("Counting coverage for {}".format(filebase + "." + feature_name))
-        run_count_reads(feature_bam, feature_outfile, bed_file, genome_sizes, use_fast_count)
+        run_count_reads(
+            feature_bam, feature_outfile, bed_file, genome_sizes, use_fast_count
+        )
     else:
-        print("Loading coverage from pre-calculated file for {}".format(filebase + "." + feature_name))
+        print(
+            "Loading coverage from pre-calculated file for {}".format(
+                filebase + "." + feature_name
+            )
+        )
 
     domain_counts = read_bed(feature_outfile)
     score_column = domain_counts.columns[-1]
 
     total_counts = count_total(feature_bam)
 
-    domain_counts = domain_counts[['chr', 'start', 'end', score_column]]
+    domain_counts = domain_counts[["chr", "start", "end", score_column]]
     featurecount = feature_name + ".readCount"
     domain_counts.rename(columns={score_column: featurecount}, inplace=True)
-    domain_counts['chr'] = domain_counts['chr'].astype('str')
+    domain_counts["chr"] = domain_counts["chr"].astype("str")
 
     df = df.merge(domain_counts.drop_duplicates())
-    #df = smart_merge(df, domain_counts.drop_duplicates())
+    # df = smart_merge(df, domain_counts.drop_duplicates())
 
     assert df.shape[0] == orig_shape, "Dimension mismatch"
 
@@ -403,39 +592,73 @@ def count_single_feature_for_bed(df, bed_file, genome_sizes, feature_bam, featur
 
     if not skip_rpkm_quantile:
         df[featurecount + ".quantile"] = df[featurecount].rank() / float(len(df))
-        df[feature_name + ".RPM.quantile"] = df[feature_name + ".RPM"].rank() / float(len(df))
-        df[feature_name + ".RPKM"] = 1e3 * df[feature_name + ".RPM"] / (df.end - df.start).astype(float)
-        df[feature_name + ".RPKM.quantile"] = df[feature_name + ".RPKM"].rank() / float(len(df))
+        df[feature_name + ".RPM.quantile"] = df[feature_name + ".RPM"].rank() / float(
+            len(df)
+        )
+        df[feature_name + ".RPKM"] = (
+            1e3 * df[feature_name + ".RPM"] / (df.end - df.start).astype(float)
+        )
+        df[feature_name + ".RPKM.quantile"] = df[feature_name + ".RPKM"].rank() / float(
+            len(df)
+        )
 
-    return df[~ df.duplicated()]
+    return df[~df.duplicated()]
+
 
 def average_features(df, feature, feature_bam_list, skip_rpkm_quantile):
-    feature_RPM_cols = [feature + "." + os.path.basename(feature_bam) + '.RPM' for feature_bam in feature_bam_list]
+    feature_RPM_cols = [
+        feature + "." + os.path.basename(feature_bam) + ".RPM"
+        for feature_bam in feature_bam_list
+    ]
 
-    df[feature + '.RPM'] = df[feature_RPM_cols].mean(axis = 1)
-    
+    df[feature + ".RPM"] = df[feature_RPM_cols].mean(axis=1)
+
     if not skip_rpkm_quantile:
-        feature_RPKM_cols = [feature + "." + os.path.basename(feature_bam) + '.RPKM' for feature_bam in feature_bam_list]
-        df[feature + '.RPM.quantile'] = df[feature + '.RPM'].rank() / float(len(df))
-        df[feature + '.RPKM'] = df[feature_RPKM_cols].mean(axis = 1)
-        df[feature + '.RPKM.quantile'] = df[feature + '.RPKM'].rank() / float(len(df))
+        feature_RPKM_cols = [
+            feature + "." + os.path.basename(feature_bam) + ".RPKM"
+            for feature_bam in feature_bam_list
+        ]
+        df[feature + ".RPM.quantile"] = df[feature + ".RPM"].rank() / float(len(df))
+        df[feature + ".RPKM"] = df[feature_RPKM_cols].mean(axis=1)
+        df[feature + ".RPKM.quantile"] = df[feature + ".RPKM"].rank() / float(len(df))
 
     return df
 
+
 # From /seq/lincRNA/Jesse/bin/scripts/JuicerUtilities.R
 #
-bed_extra_colnames = ["name", "score", "strand", "thickStart", "thickEnd", "itemRgb", "blockCount", "blockSizes", "blockStarts"]
-#JN: 9/13/19: Don't assume chromosomes start with 'chr'
-#chromosomes = ['chr' + str(entry) for entry in list(range(1,23)) + ['M','X','Y']]   # should pass this in as an input file to specify chromosome order
-def read_bed(filename, extra_colnames=bed_extra_colnames, chr=None, sort=False, skip_chr_sorting=True):
+bed_extra_colnames = [
+    "name",
+    "score",
+    "strand",
+    "thickStart",
+    "thickEnd",
+    "itemRgb",
+    "blockCount",
+    "blockSizes",
+    "blockStarts",
+]
+
+
+# JN: 9/13/19: Don't assume chromosomes start with 'chr'
+# chromosomes = ['chr' + str(entry) for entry in list(range(1,23)) + ['M','X','Y']]   # should pass this in as an input file to specify chromosome order
+def read_bed(
+    filename,
+    extra_colnames=bed_extra_colnames,
+    chr=None,
+    sort=False,
+    skip_chr_sorting=True,
+):
     skip = 1 if ("track" in open(filename, "r").readline()) else 0
     names = ["chr", "start", "end"] + extra_colnames
-    result = pd.read_table(filename, names=names, header=None, skiprows=skip, comment='#')
-    result = result.dropna(axis=1, how='all')  # drop empty columns
+    result = pd.read_table(
+        filename, names=names, header=None, skiprows=skip, comment="#"
+    )
+    result = result.dropna(axis=1, how="all")  # drop empty columns
     assert result.columns[0] == "chr"
 
-    #result['chr'] = pd.Categorical(result['chr'], chromosomes, ordered=True)
-    result['chr'] = pd.Categorical(result['chr'], ordered=True)
+    # result['chr'] = pd.Categorical(result['chr'], chromosomes, ordered=True)
+    result["chr"] = pd.Categorical(result["chr"], ordered=True)
     if chr is not None:
         result = result[result.chr == chr]
     if not skip_chr_sorting:
@@ -448,30 +671,44 @@ def read_bed(filename, extra_colnames=bed_extra_colnames, chr=None, sort=False, 
 def read_bedgraph(filename):
     read_bed(filename, extra_colnames=["score"], skip_chr_sorting=True)
 
+
 def count_bam_mapped(bam_file):
     # Counts number of reads in a BAM file WITHOUT iterating.  Requires that the BAM is indexed
     # chromosomes = ['chr' + str(x) for x in range(1,23)] + ['chrX'] + ['chrY']
-    command = ("samtools idxstats " + bam_file)
+    command = "samtools idxstats " + bam_file
     data = check_output(command, shell=True)
     lines = data.decode("ascii").split("\n")
-    #vals = list(int(l.split("\t")[2]) for l in lines[:-1] if l.split("\t")[0] in chromosomes)
+    # vals = list(int(l.split("\t")[2]) for l in lines[:-1] if l.split("\t")[0] in chromosomes)
     vals = list(int(l.split("\t")[2]) for l in lines[:-1])
     if not sum(vals) > 0:
         raise ValueError("Error counting BAM file: count <= 0")
     return sum(vals)
 
+
 def count_tagalign_total(tagalign):
-    #result = int(check_output("zcat " + tagalign + " | wc -l", shell=True))
-    result = int(check_output("zcat {} | grep -E 'chr[1-9]|chr1[0-9]|chr2[0-2]|chrX|chrY' | wc -l".format(tagalign), shell=True))
-    assert (result > 0)
+    # result = int(check_output("zcat " + tagalign + " | wc -l", shell=True))
+    result = int(
+        check_output(
+            "zcat {} | grep -E 'chr[1-9]|chr1[0-9]|chr2[0-2]|chrX|chrY' | wc -l".format(
+                tagalign
+            ),
+            shell=True,
+        )
+    )
+    assert result > 0
     return result
+
 
 def count_bigwig_total(bw_file):
     from pyBigWig import open as open_bigwig
+
     bw = open_bigwig(bw_file)
     result = sum(l * bw.stats(ch, 0, l, "mean")[0] for ch, l in bw.chroms().items())
-    assert (abs(result) > 0)  ## BigWig could have negative values, e.g. the negative-strand GroCAP bigwigs
+    assert (
+        abs(result) > 0
+    )  ## BigWig could have negative values, e.g. the negative-strand GroCAP bigwigs
     return result
+
 
 def count_total(infile):
     if infile.endswith(".tagAlign.gz") or infile.endswith(".tagAlign.bgz"):
@@ -485,6 +722,7 @@ def count_total(infile):
 
     return total_counts
 
+
 def parse_params_file(args):
     # Parse parameters file and return params dictionary
     params = {}
@@ -495,34 +733,38 @@ def parse_params_file(args):
     if args.expression_table:
         params["expression_table"] = args.expression_table.split(",")
     else:
-        params["expression_table"] = ''
+        params["expression_table"] = ""
 
-    return(params)
+    return params
+
 
 def get_features(args):
     features = {}
 
     if args.H3K27ac:
-        features['H3K27ac'] = args.H3K27ac.split(",")
-    
+        features["H3K27ac"] = args.H3K27ac.split(",")
+
     if args.ATAC:
-        features['ATAC'] = args.ATAC.split(",")
-    
+        features["ATAC"] = args.ATAC.split(",")
+
     if args.DHS:
-        features['DHS'] = args.DHS.split(",")
+        features["DHS"] = args.DHS.split(",")
 
     if args.supplementary_features is not None:
         supp = pd.read_csv(args.supplementary_features, sep="\t")
-        for idx,row in supp.iterrows():
-            features[row['feature_name']] = row['file'].split(",")
+        for idx, row in supp.iterrows():
+            features[row["feature_name"]] = row["file"].split(",")
 
     return features
+
 
 def determine_accessibility_feature(args):
     if args.default_accessibility_feature is not None:
         return args.default_accessibility_feature
     elif (not args.ATAC) and (not args.DHS):
-        raise RuntimeError("Both DHS and ATAC have been provided. Must set one file to be the default accessibility feature!")
+        raise RuntimeError(
+            "Both DHS and ATAC have been provided. Must set one file to be the default accessibility feature!"
+        )
     elif args.ATAC:
         return "ATAC"
     elif args.DHS:
@@ -530,70 +772,120 @@ def determine_accessibility_feature(args):
     else:
         raise RuntimeError("At least one of ATAC or DHS must be provided!")
 
+
 def compute_activity(df, access_col):
     if access_col == "DHS":
-        if 'H3K27ac.RPM' in df.columns:
-            df['activity_base'] = np.sqrt(df['normalized_h3K27ac'] * df['normalized_dhs'])
-            df['activity_base_no_qnorm'] = np.sqrt(df['H3K27ac.RPM'] * df['DHS.RPM'])
+        if "H3K27ac.RPM" in df.columns:
+            df["activity_base"] = np.sqrt(
+                df["normalized_h3K27ac"] * df["normalized_dhs"]
+            )
+            df["activity_base_no_qnorm"] = np.sqrt(df["H3K27ac.RPM"] * df["DHS.RPM"])
         else:
-            df['activity_base'] = df['normalized_dhs']
-            df['activity_base_no_qnorm'] = df['DHS.RPM']
+            df["activity_base"] = df["normalized_dhs"]
+            df["activity_base_no_qnorm"] = df["DHS.RPM"]
     elif access_col == "ATAC":
-        if 'H3K27ac.RPM' in df.columns:
-            df['activity_base'] = np.sqrt(df['normalized_h3K27ac'] * df['normalized_atac'])
-            df['activity_base_no_qnorm'] = np.sqrt(df['H3K27ac.RPM'] * df['ATAC.RPM'])
+        if "H3K27ac.RPM" in df.columns:
+            df["activity_base"] = np.sqrt(
+                df["normalized_h3K27ac"] * df["normalized_atac"]
+            )
+            df["activity_base_no_qnorm"] = np.sqrt(df["H3K27ac.RPM"] * df["ATAC.RPM"])
         else:
-            df['activity_base'] = df['normalized_atac']
-            df['activity_base_no_qnorm'] = df['ATAC.RPM']
+            df["activity_base"] = df["normalized_atac"]
+            df["activity_base_no_qnorm"] = df["ATAC.RPM"]
     else:
         raise RuntimeError("At least one of ATAC or DHS must be provided!")
 
     return df
 
-def run_qnorm(df, qnorm, qnorm_method = "rank", separate_promoters = True):
+
+def run_qnorm(df, qnorm, qnorm_method="rank", separate_promoters=True):
     # Quantile normalize epigenetic data to a reference
     #
     # Option to qnorm promoters and nonpromoters separately
 
     if qnorm is None:
-        if 'H3K27ac.RPM' in df.columns: df['normalized_h3K27ac'] = df['H3K27ac.RPM']
-        if 'DHS.RPM' in df.columns: df['normalized_dhs'] = df['DHS.RPM']
-        if 'ATAC.RPM' in df.columns: df['normalized_atac'] = df['ATAC.RPM']
+        if "H3K27ac.RPM" in df.columns:
+            df["normalized_h3K27ac"] = df["H3K27ac.RPM"]
+        if "DHS.RPM" in df.columns:
+            df["normalized_dhs"] = df["DHS.RPM"]
+        if "ATAC.RPM" in df.columns:
+            df["normalized_atac"] = df["ATAC.RPM"]
     else:
-        qnorm = pd.read_csv(qnorm, sep = "\t")
-        nRegions = df.shape[0] 
-        col_dict = {'DHS.RPM' : 'normalized_dhs', 'ATAC.RPM' : 'normalized_atac', 'H3K27ac.RPM' : 'normalized_h3K27ac'}
+        qnorm = pd.read_csv(qnorm, sep="\t")
+        nRegions = df.shape[0]
+        col_dict = {
+            "DHS.RPM": "normalized_dhs",
+            "ATAC.RPM": "normalized_atac",
+            "H3K27ac.RPM": "normalized_h3K27ac",
+        }
 
         # & operator doesn't work in newer versions https://pastebin.com/8d2Ra9L1
-        for col in set(df.columns.intersection(col_dict.keys())): 
-            #if there is no ATAC.RPM in the qnorm file, but there is ATAC.RPM in enhancers, then qnorm ATAC to DHS
-            if col == 'ATAC.RPM' and 'ATAC.RPM' not in qnorm.columns:
-                qnorm['ATAC.RPM'] = qnorm['DHS.RPM']
+        for col in set(df.columns.intersection(col_dict.keys())):
+            # if there is no ATAC.RPM in the qnorm file, but there is ATAC.RPM in enhancers, then qnorm ATAC to DHS
+            if col == "ATAC.RPM" and "ATAC.RPM" not in qnorm.columns:
+                qnorm["ATAC.RPM"] = qnorm["DHS.RPM"]
 
             if not separate_promoters:
-                qnorm = qnorm.loc[qnorm['enh_class' == "any"]]
+                qnorm = qnorm.loc[qnorm["enh_class" == "any"]]
                 if qnorm_method == "rank":
-                    interpfunc = interpolate.interp1d(qnorm['rank'], qnorm[col], kind='linear', fill_value='extrapolate')
-                    df[col_dict[col]] = interpfunc((1 - df[col + ".quantile"]) * nRegions).clip(0)
+                    interpfunc = interpolate.interp1d(
+                        qnorm["rank"],
+                        qnorm[col],
+                        kind="linear",
+                        fill_value="extrapolate",
+                    )
+                    df[col_dict[col]] = interpfunc(
+                        (1 - df[col + ".quantile"]) * nRegions
+                    ).clip(0)
                 elif qnorm_method == "quantile":
-                    interpfunc = interpolate.interp1d(qnorm['quantile'], qnorm[col], kind='linear', fill_value='extrapolate')
+                    interpfunc = interpolate.interp1d(
+                        qnorm["quantile"],
+                        qnorm[col],
+                        kind="linear",
+                        fill_value="extrapolate",
+                    )
                     df[col_dict[col]] = interpfunc(df[col + ".quantile"]).clip(0)
             else:
-                for enh_class in ['promoter','nonpromoter']:
-                    this_qnorm = qnorm.loc[qnorm['enh_class'] == enh_class]
+                for enh_class in ["promoter", "nonpromoter"]:
+                    this_qnorm = qnorm.loc[qnorm["enh_class"] == enh_class]
 
-                    #Need to recompute quantiles within each class
-                    if enh_class == 'promoter':
-                        this_idx = df.index[np.logical_or(df['class'] == "tss", df['class'] == "promoter")]
+                    # Need to recompute quantiles within each class
+                    if enh_class == "promoter":
+                        this_idx = df.index[
+                            np.logical_or(
+                                df["class"] == "tss", df["class"] == "promoter"
+                            )
+                        ]
                     else:
-                        this_idx = df.index[np.logical_and(df['class'] != "tss" , df['class'] != "promoter")]
-                    df.loc[this_idx, col + enh_class + ".quantile"] = df.loc[this_idx, col].rank()/len(this_idx)
+                        this_idx = df.index[
+                            np.logical_and(
+                                df["class"] != "tss", df["class"] != "promoter"
+                            )
+                        ]
+                    df.loc[this_idx, col + enh_class + ".quantile"] = df.loc[
+                        this_idx, col
+                    ].rank() / len(this_idx)
 
                     if qnorm_method == "rank":
-                        interpfunc = interpolate.interp1d(this_qnorm['rank'], this_qnorm[col], kind='linear', fill_value='extrapolate')
-                        df.loc[this_idx, col_dict[col]] = interpfunc((1 - df.loc[this_idx, col + enh_class + ".quantile"]) * len(this_idx)).clip(0)
+                        interpfunc = interpolate.interp1d(
+                            this_qnorm["rank"],
+                            this_qnorm[col],
+                            kind="linear",
+                            fill_value="extrapolate",
+                        )
+                        df.loc[this_idx, col_dict[col]] = interpfunc(
+                            (1 - df.loc[this_idx, col + enh_class + ".quantile"])
+                            * len(this_idx)
+                        ).clip(0)
                     elif qnorm_method == "quantile":
-                        interpfunc = interpolate.interp1d(this_qnorm['quantile'], this_qnorm[col], kind='linear', fill_value='extrapolate')
-                        df.loc[this_idx, col_dict[col]] = interpfunc(df.loc[this_idx, col + enh_class + ".quantile"]).clip(0)
+                        interpfunc = interpolate.interp1d(
+                            this_qnorm["quantile"],
+                            this_qnorm[col],
+                            kind="linear",
+                            fill_value="extrapolate",
+                        )
+                        df.loc[this_idx, col_dict[col]] = interpfunc(
+                            df.loc[this_idx, col + enh_class + ".quantile"]
+                        ).clip(0)
 
     return df

--- a/workflow/scripts/peaks.py
+++ b/workflow/scripts/peaks.py
@@ -5,109 +5,183 @@ import os.path
 from tools import *
 from neighborhoods import *
 
-def make_candidate_regions_from_summits(macs_peaks, accessibility_file, genome_sizes, regions_includelist, regions_blocklist, n_enhancers, peak_extend, outdir):
+
+def make_candidate_regions_from_summits(
+    macs_peaks,
+    accessibility_file,
+    genome_sizes,
+    regions_includelist,
+    regions_blocklist,
+    n_enhancers,
+    peak_extend,
+    outdir,
+):
     ## Generate enhancer regions from MACS summits: 1. Count reads in DHS peaks 2. Take top N regions, get summits, extend summits, merge
-    
-    outfile = os.path.join(outdir, os.path.basename(macs_peaks) + ".candidateRegions.bed") # output file name for candidateRegions.bed
-    raw_counts_out = [] # initialize list for output file names
-    for access_in in accessibility_file: # loop through input accessibilty files
-       raw_counts_out.append(os.path.join(outdir, os.path.basename(macs_peaks) + "." + os.path.basename(access_in) + ".Counts.bed")) # add corresponding output file name
-    if regions_includelist:
-    	includelist_command = "(bedtools intersect -a {regions_includelist} -b {genome_sizes}.bed -wa | cut -f 1-3 && cat) |"
-    else:
-    	includelist_command = ""
 
-    if regions_blocklist:
-    	blocklist_command = "bedtools intersect -v -wa -a stdin -b {regions_blocklist} | "
-    else:
-    	blocklist_command = ""
-
-    #1. Count DHS/ATAC reads in candidate regions
-    #run_count_reads(accessibility_file, raw_counts_outfile, macs_peaks, genome_sizes, use_fast_count=True)
-    
-    # 1. Count DHS/ATAC reads in candidate regions for all accessibility files provided, and return the filename of the average # reads
-    reads_out = count_reads_over_peaks(accessibility_file, raw_counts_out, macs_peaks, genome_sizes, outdir, use_fast_count=True)
-
-    #2. Take top N regions, get summits, extend summits, merge, remove blocklist, add includelist, sort and merge
-    #use -sorted in intersect command? Not worth it, both files are small
-    command = "bedtools sort -i {reads_out} -faidx {genome_sizes} | bedtools merge -i stdin -c 4 -o max | sort -nr -k 4 | head -n {n_enhancers} |" + \
-        "bedtools intersect -b stdin -a {macs_peaks} -wa |" + \
-        "awk '{{print $1 \"\\t\" $2 + $10 \"\\t\" $2 + $10}}' |" + \
-        "bedtools slop -i stdin -b {peak_extend} -g {genome_sizes} |" + \
-        "bedtools sort -i stdin -faidx {genome_sizes} |" + \
-        "bedtools merge -i stdin | " + \
-        blocklist_command + \
-        "cut -f 1-3 | " + includelist_command + \
-        "bedtools sort -i stdin -faidx {genome_sizes} | bedtools merge -i stdin > {outfile}"
-
-    command = command.format(**locals())
-
-    p = Popen(command, stdout=PIPE, stderr=PIPE, shell=True)
-    print("Running: " + command)
-    (stdoutdata, stderrdata) = p.communicate()
-    err = str(stderrdata, 'utf-8')
-
-    return stdoutdata
-
-
-def make_candidate_regions_from_peaks(macs_peaks, accessibility_file, genome_sizes, regions_includelist, regions_blocklist, n_enhancers, peak_extend, minPeakWidth, outdir):
-    ## Generate enhancer regions from MACS narrowPeak - do not use summits
-    outfile = os.path.join(outdir, os.path.basename(macs_peaks) + ".candidateRegions.bed")
-    raw_counts_out = [] # initialize list for output file names
-    for access_in in accessibility_file: # loop through input accessibilty files
-       raw_counts_out.append(os.path.join(outdir, os.path.basename(macs_peaks) + "." + os.path.basename(access_in) + ".Counts.bed")) # add corresponding output file name
-       
+    outfile = os.path.join(
+        outdir, os.path.basename(macs_peaks) + ".candidateRegions.bed"
+    )  # output file name for candidateRegions.bed
+    raw_counts_out = []  # initialize list for output file names
+    for access_in in accessibility_file:  # loop through input accessibilty files
+        raw_counts_out.append(
+            os.path.join(
+                outdir,
+                os.path.basename(macs_peaks)
+                + "."
+                + os.path.basename(access_in)
+                + ".Counts.bed",
+            )
+        )  # add corresponding output file name
     if regions_includelist:
         includelist_command = "(bedtools intersect -a {regions_includelist} -b {genome_sizes}.bed -wa | cut -f 1-3 && cat) |"
     else:
         includelist_command = ""
 
     if regions_blocklist:
-        blocklist_command = "bedtools intersect -v -wa -a stdin -b {regions_blocklist} | "
+        blocklist_command = (
+            "bedtools intersect -v -wa -a stdin -b {regions_blocklist} | "
+        )
     else:
         blocklist_command = ""
 
-    #1. Count DHS/ATAC reads in candidate regions
-    reads_out = count_reads_over_peaks(accessibility_file, raw_counts_out, macs_peaks, genome_sizes, outdir, use_fast_count=True)
+    # 1. Count DHS/ATAC reads in candidate regions
+    # run_count_reads(accessibility_file, raw_counts_outfile, macs_peaks, genome_sizes, use_fast_count=True)
 
-    #2. Take top N regions, extend peaks (min size 500), merge, remove blocklist, add includelist, sort and merge
-    #use -sorted in intersect command? Not worth it, both files are small
-    command = "bedtools sort -i {reads_out} -faidx {genome_sizes} | bedtools merge -i stdin -c 4 -o max | sort -nr -k 4 | head -n {n_enhancers} |" + \
-        "bedtools intersect -b stdin -a {macs_peaks} -wa |" + \
-        "bedtools slop -i stdin -b {peak_extend} -g {genome_sizes} |" + \
-        "awk '{{ l=$3-$2; if (l < {minPeakWidth}) {{ $2 = $2 - int(({minPeakWidth}-l)/2); $3 = $3 + int(({minPeakWidth}-l)/2) }} print $1 \"\\t\" $2 \"\\t\" $3}}' |" + \
-        "bedtools sort -i stdin -faidx {genome_sizes} |" + \
-        "bedtools merge -i stdin | " + \
-        blocklist_command + \
-        "cut -f 1-3 | " + includelist_command + \
-        "bedtools sort -i stdin -faidx {genome_sizes} | bedtools merge -i stdin > {outfile}"
+    # 1. Count DHS/ATAC reads in candidate regions for all accessibility files provided, and return the filename of the average # reads
+    reads_out = count_reads_over_peaks(
+        accessibility_file,
+        raw_counts_out,
+        macs_peaks,
+        genome_sizes,
+        outdir,
+        use_fast_count=True,
+    )
+
+    # 2. Take top N regions, get summits, extend summits, merge, remove blocklist, add includelist, sort and merge
+    # use -sorted in intersect command? Not worth it, both files are small
+    command = (
+        "bedtools sort -i {reads_out} -faidx {genome_sizes} | bedtools merge -i stdin -c 4 -o max | sort -nr -k 4 | head -n {n_enhancers} |"
+        + "bedtools intersect -b stdin -a {macs_peaks} -wa |"
+        + 'awk \'{{print $1 "\\t" $2 + $10 "\\t" $2 + $10}}\' |'
+        + "bedtools slop -i stdin -b {peak_extend} -g {genome_sizes} |"
+        + "bedtools sort -i stdin -faidx {genome_sizes} |"
+        + "bedtools merge -i stdin | "
+        + blocklist_command
+        + "cut -f 1-3 | "
+        + includelist_command
+        + "bedtools sort -i stdin -faidx {genome_sizes} | bedtools merge -i stdin > {outfile}"
+    )
 
     command = command.format(**locals())
 
     p = Popen(command, stdout=PIPE, stderr=PIPE, shell=True)
     print("Running: " + command)
     (stdoutdata, stderrdata) = p.communicate()
-    err = str(stderrdata, 'utf-8')
-    if not err == '':
+    err = str(stderrdata, "utf-8")
+
+    return stdoutdata
+
+
+def make_candidate_regions_from_peaks(
+    macs_peaks,
+    accessibility_file,
+    genome_sizes,
+    regions_includelist,
+    regions_blocklist,
+    n_enhancers,
+    peak_extend,
+    minPeakWidth,
+    outdir,
+):
+    ## Generate enhancer regions from MACS narrowPeak - do not use summits
+    outfile = os.path.join(
+        outdir, os.path.basename(macs_peaks) + ".candidateRegions.bed"
+    )
+    raw_counts_out = []  # initialize list for output file names
+    for access_in in accessibility_file:  # loop through input accessibilty files
+        raw_counts_out.append(
+            os.path.join(
+                outdir,
+                os.path.basename(macs_peaks)
+                + "."
+                + os.path.basename(access_in)
+                + ".Counts.bed",
+            )
+        )  # add corresponding output file name
+
+    if regions_includelist:
+        includelist_command = "(bedtools intersect -a {regions_includelist} -b {genome_sizes}.bed -wa | cut -f 1-3 && cat) |"
+    else:
+        includelist_command = ""
+
+    if regions_blocklist:
+        blocklist_command = (
+            "bedtools intersect -v -wa -a stdin -b {regions_blocklist} | "
+        )
+    else:
+        blocklist_command = ""
+
+    # 1. Count DHS/ATAC reads in candidate regions
+    reads_out = count_reads_over_peaks(
+        accessibility_file,
+        raw_counts_out,
+        macs_peaks,
+        genome_sizes,
+        outdir,
+        use_fast_count=True,
+    )
+
+    # 2. Take top N regions, extend peaks (min size 500), merge, remove blocklist, add includelist, sort and merge
+    # use -sorted in intersect command? Not worth it, both files are small
+    command = (
+        "bedtools sort -i {reads_out} -faidx {genome_sizes} | bedtools merge -i stdin -c 4 -o max | sort -nr -k 4 | head -n {n_enhancers} |"
+        + "bedtools intersect -b stdin -a {macs_peaks} -wa |"
+        + "bedtools slop -i stdin -b {peak_extend} -g {genome_sizes} |"
+        + 'awk \'{{ l=$3-$2; if (l < {minPeakWidth}) {{ $2 = $2 - int(({minPeakWidth}-l)/2); $3 = $3 + int(({minPeakWidth}-l)/2) }} print $1 "\\t" $2 "\\t" $3}}\' |'
+        + "bedtools sort -i stdin -faidx {genome_sizes} |"
+        + "bedtools merge -i stdin | "
+        + blocklist_command
+        + "cut -f 1-3 | "
+        + includelist_command
+        + "bedtools sort -i stdin -faidx {genome_sizes} | bedtools merge -i stdin > {outfile}"
+    )
+
+    command = command.format(**locals())
+
+    p = Popen(command, stdout=PIPE, stderr=PIPE, shell=True)
+    print("Running: " + command)
+    (stdoutdata, stderrdata) = p.communicate()
+    err = str(stderrdata, "utf-8")
+    if not err == "":
         raise RuntimeError("Command failed.")
 
     return stdoutdata
-    
+
+
 # count reads over however many DHS files and return average
-def count_reads_over_peaks(accessibility_file, raw_counts_out, macs_peaks, genome_sizes, outdir, use_fast_count=True):
+def count_reads_over_peaks(
+    accessibility_file,
+    raw_counts_out,
+    macs_peaks,
+    genome_sizes,
+    outdir,
+    use_fast_count=True,
+):
     for access_in, counts_out in zip(accessibility_file, raw_counts_out):
         run_count_reads(access_in, counts_out, macs_peaks, genome_sizes, use_fast_count)
         nFiles = len(raw_counts_out)
-        
+
     if nFiles > 1:
-        avg_out = os.path.join(outdir, os.path.basename(macs_peaks) + ".averageAccessibility.Counts.bed")
-        df1 = pd.read_csv(raw_counts_out[0], sep='\t', header=None)
+        avg_out = os.path.join(
+            outdir, os.path.basename(macs_peaks) + ".averageAccessibility.Counts.bed"
+        )
+        df1 = pd.read_csv(raw_counts_out[0], sep="\t", header=None)
         totalCounts = df1[3]
         for i in range(1, nFiles):
-            dfx = pd.read_csv(raw_counts_out[i], sep='\t', header=None, usecols=[3])
+            dfx = pd.read_csv(raw_counts_out[i], sep="\t", header=None, usecols=[3])
             print(len(dfx))
             df1[3] = df1[3].add(dfx[3])
-        df1[3] = df1[3]/nFiles
+        df1[3] = df1[3] / nFiles
         df1.to_csv(avg_out, header=None, index=None, sep="\t")
         return avg_out
     else:

--- a/workflow/scripts/predict.py
+++ b/workflow/scripts/predict.py
@@ -7,53 +7,155 @@ import numpy as np
 import sys, traceback, os, os.path
 import time
 
+
 def get_model_argument_parser():
-    class formatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter):
+    class formatter(
+        argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter
+    ):
         pass
 
-    parser = argparse.ArgumentParser(description='Predict enhancer relative effects.',
-                                     formatter_class=formatter)
-    readable = argparse.FileType('r')
+    parser = argparse.ArgumentParser(
+        description="Predict enhancer relative effects.", formatter_class=formatter
+    )
+    readable = argparse.FileType("r")
 
-    #Basic parameters
-    parser.add_argument('--enhancers', required=True, help="Candidate enhancer regions. Formatted as the EnhancerList.txt file produced by run.neighborhoods.py")
-    parser.add_argument('--genes', required=True, help="Genes to make predictions for. Formatted as the GeneList.txt file produced by run.neighborhoods.py")
-    parser.add_argument('--outdir', required=True, help="output directory")
-    parser.add_argument('--window', type=int, default=5000000, help="Make predictions for all candidate elements within this distance of the gene's TSS")
-    parser.add_argument('--score_column', default='ABC.Score', help="Column name of score to use for thresholding")
-    parser.add_argument('--threshold', type=float, required=True, default=.022, help="Threshold on ABC Score (--score_column) to call a predicted positive")
-    parser.add_argument('--cellType', help="Name of cell type")
-    parser.add_argument('--chrom_sizes', help="Chromosome sizes file")
+    # Basic parameters
+    parser.add_argument(
+        "--enhancers",
+        required=True,
+        help="Candidate enhancer regions. Formatted as the EnhancerList.txt file produced by run.neighborhoods.py",
+    )
+    parser.add_argument(
+        "--genes",
+        required=True,
+        help="Genes to make predictions for. Formatted as the GeneList.txt file produced by run.neighborhoods.py",
+    )
+    parser.add_argument("--outdir", required=True, help="output directory")
+    parser.add_argument(
+        "--window",
+        type=int,
+        default=5000000,
+        help="Make predictions for all candidate elements within this distance of the gene's TSS",
+    )
+    parser.add_argument(
+        "--score_column",
+        default="ABC.Score",
+        help="Column name of score to use for thresholding",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        required=True,
+        default=0.022,
+        help="Threshold on ABC Score (--score_column) to call a predicted positive",
+    )
+    parser.add_argument("--cellType", help="Name of cell type")
+    parser.add_argument("--chrom_sizes", help="Chromosome sizes file")
 
-    #hic
-    #To do: validate params
-    parser.add_argument('--HiCdir', default=None, help="HiC directory")
-    parser.add_argument('--hic_resolution', type=int, help="HiC resolution")
-    parser.add_argument('--tss_hic_contribution', type=float, default=100, help="Weighting of diagonal bin of hic matrix as a percentage of the maximum of its neighboring bins")
-    parser.add_argument('--hic_pseudocount_distance', type=int, default=1e6, help="A pseudocount is added equal to the powerlaw fit at this distance")
-    parser.add_argument('--hic_type', default = 'juicebox', choices=['juicebox','bedpe', 'avg'], help="format of hic files")
-    parser.add_argument('--hic_is_doubly_stochastic', action='store_true', help="If hic matrix is already DS, can skip this step")
+    # hic
+    # To do: validate params
+    parser.add_argument("--HiCdir", default=None, help="HiC directory")
+    parser.add_argument("--hic_resolution", type=int, help="HiC resolution")
+    parser.add_argument(
+        "--tss_hic_contribution",
+        type=float,
+        default=100,
+        help="Weighting of diagonal bin of hic matrix as a percentage of the maximum of its neighboring bins",
+    )
+    parser.add_argument(
+        "--hic_pseudocount_distance",
+        type=int,
+        default=1e6,
+        help="A pseudocount is added equal to the powerlaw fit at this distance",
+    )
+    parser.add_argument(
+        "--hic_type",
+        default="juicebox",
+        choices=["juicebox", "bedpe", "avg"],
+        help="format of hic files",
+    )
+    parser.add_argument(
+        "--hic_is_doubly_stochastic",
+        action="store_true",
+        help="If hic matrix is already DS, can skip this step",
+    )
 
-    #Power law
-    parser.add_argument('--scale_hic_using_powerlaw', action="store_true", help="Scale Hi-C values using powerlaw relationship")
-    parser.add_argument('--hic_gamma', type=float, default=.87, help="powerlaw exponent of hic data. Must be positive")
-    parser.add_argument('--hic_scale', type=float, help="scale of hic data. Must be positive")
-    parser.add_argument('--hic_gamma_reference', type=float, default=.87, help="powerlaw exponent to scale to. Must be positive")
+    # Power law
+    parser.add_argument(
+        "--scale_hic_using_powerlaw",
+        action="store_true",
+        help="Scale Hi-C values using powerlaw relationship",
+    )
+    parser.add_argument(
+        "--hic_gamma",
+        type=float,
+        default=0.87,
+        help="powerlaw exponent of hic data. Must be positive",
+    )
+    parser.add_argument(
+        "--hic_scale", type=float, help="scale of hic data. Must be positive"
+    )
+    parser.add_argument(
+        "--hic_gamma_reference",
+        type=float,
+        default=0.87,
+        help="powerlaw exponent to scale to. Must be positive",
+    )
 
-    #Genes to run through model
-    parser.add_argument('--run_all_genes', action='store_true', help="Do not check for gene expression, make predictions for all genes")
-    parser.add_argument('--expression_cutoff', type=float, default=1, help="Make predictions for genes with expression higher than this value")
-    parser.add_argument('--promoter_activity_quantile_cutoff', type=float, default=.4, help="Quantile cutoff on promoter activity. Used to consider a gene 'expressed' in the absence of expression data")
+    # Genes to run through model
+    parser.add_argument(
+        "--run_all_genes",
+        action="store_true",
+        help="Do not check for gene expression, make predictions for all genes",
+    )
+    parser.add_argument(
+        "--expression_cutoff",
+        type=float,
+        default=1,
+        help="Make predictions for genes with expression higher than this value",
+    )
+    parser.add_argument(
+        "--promoter_activity_quantile_cutoff",
+        type=float,
+        default=0.4,
+        help="Quantile cutoff on promoter activity. Used to consider a gene 'expressed' in the absence of expression data",
+    )
 
-    #Output formatting
-    parser.add_argument('--make_all_putative', action="store_true", help="Make big file with concatenation of all genes file")
-    parser.add_argument('--use_hdf5', action="store_true", help="Write AllPutative file in hdf5 format instead of tab-delimited")
+    # Output formatting
+    parser.add_argument(
+        "--make_all_putative",
+        action="store_true",
+        help="Make big file with concatenation of all genes file",
+    )
+    parser.add_argument(
+        "--use_hdf5",
+        action="store_true",
+        help="Write AllPutative file in hdf5 format instead of tab-delimited",
+    )
 
-    #Other
-    parser.add_argument('--tss_slop', type=int, default=500, help="Distance from tss to search for self-promoters")
-    parser.add_argument('--chromosomes', default="all", help="chromosomes to make predictions for. Defaults to intersection of all chromosomes in --genes and --enhancers")
-    parser.add_argument('--include_chrY', '-y', action='store_true', help="Make predictions on Y chromosome")
-    parser.add_argument('--include_self_promoter', action='store_true', help="Include self-promoter elements as enhancers ")
+    # Other
+    parser.add_argument(
+        "--tss_slop",
+        type=int,
+        default=500,
+        help="Distance from tss to search for self-promoters",
+    )
+    parser.add_argument(
+        "--chromosomes",
+        default="all",
+        help="chromosomes to make predictions for. Defaults to intersection of all chromosomes in --genes and --enhancers",
+    )
+    parser.add_argument(
+        "--include_chrY",
+        "-y",
+        action="store_true",
+        help="Make predictions on Y chromosome",
+    )
+    parser.add_argument(
+        "--include_self_promoter",
+        action="store_true",
+        help="Include self-promoter elements as enhancers ",
+    )
 
     return parser
 
@@ -61,6 +163,7 @@ def get_model_argument_parser():
 def get_predict_argument_parser():
     parser = get_model_argument_parser()
     return parser
+
 
 def main():
     parser = get_predict_argument_parser()
@@ -72,92 +175,183 @@ def main():
         os.makedirs(args.outdir)
 
     write_params(args, os.path.join(args.outdir, "parameters.predict.txt"))
-    
+
     print("reading genes")
-    genes = pd.read_csv(args.genes, sep = "\t")
-    genes = determine_expressed_genes(genes, args.expression_cutoff, args.promoter_activity_quantile_cutoff)
-    genes = genes.loc[:,['chr','symbol','tss','Expression','PromoterActivityQuantile','isExpressed', 'DHS.RPKM.quantile.TSS1Kb']]
-    genes.columns = ['chr','TargetGene', 'TargetGeneTSS', 'TargetGeneExpression', 'TargetGenePromoterActivityQuantile','TargetGeneIsExpressed', 'normalized_dhs']
+    genes = pd.read_csv(args.genes, sep="\t")
+    genes = determine_expressed_genes(
+        genes, args.expression_cutoff, args.promoter_activity_quantile_cutoff
+    )
+    genes = genes.loc[
+        :,
+        [
+            "chr",
+            "symbol",
+            "tss",
+            "Expression",
+            "PromoterActivityQuantile",
+            "isExpressed",
+            "DHS.RPKM.quantile.TSS1Kb",
+        ],
+    ]
+    genes.columns = [
+        "chr",
+        "TargetGene",
+        "TargetGeneTSS",
+        "TargetGeneExpression",
+        "TargetGenePromoterActivityQuantile",
+        "TargetGeneIsExpressed",
+        "normalized_dhs",
+    ]
 
     print("reading enhancers")
-    enhancers_full = pd.read_csv(args.enhancers, sep = "\t")
-    #TO DO
-    #Think about which columns to include
-    enhancers = enhancers_full.loc[:,['chr','start','end','name','class','activity_base','normalized_dhs' ]]
-    enhancers['activity_base_squared'] = enhancers['activity_base']**2
-    #Initialize Prediction files
+    enhancers_full = pd.read_csv(args.enhancers, sep="\t")
+    # TO DO
+    # Think about which columns to include
+    enhancers = enhancers_full.loc[
+        :, ["chr", "start", "end", "name", "class", "activity_base", "normalized_dhs"]
+    ]
+    enhancers["activity_base_squared"] = enhancers["activity_base"] ** 2
+    # Initialize Prediction files
     pred_file_full = os.path.join(args.outdir, "EnhancerPredictionsFull.csv")
     pred_file_slim = os.path.join(args.outdir, "EnhancerPredictions.csv")
     pred_file_bedpe = os.path.join(args.outdir, "EnhancerPredictions.bedpe")
-    all_pred_file_expressed = os.path.join(args.outdir, "EnhancerPredictionsAllPutative.txt.gz")
-    all_pred_file_nonexpressed = os.path.join(args.outdir, "EnhancerPredictionsAllPutativeNonExpressedGenes.txt.gz")
-    variant_overlap_file = os.path.join(args.outdir, "EnhancerPredictionsAllPutative.ForVariantOverlap.shrunk150bp.txt.gz")
+    all_pred_file_expressed = os.path.join(
+        args.outdir, "EnhancerPredictionsAllPutative.txt.gz"
+    )
+    all_pred_file_nonexpressed = os.path.join(
+        args.outdir, "EnhancerPredictionsAllPutativeNonExpressedGenes.txt.gz"
+    )
+    variant_overlap_file = os.path.join(
+        args.outdir,
+        "EnhancerPredictionsAllPutative.ForVariantOverlap.shrunk150bp.txt.gz",
+    )
     all_putative_list = []
 
-    #Make predictions
+    # Make predictions
     if args.chromosomes == "all":
-        chromosomes = set(genes['chr']).intersection(set(enhancers['chr'])) 
+        chromosomes = set(genes["chr"]).intersection(set(enhancers["chr"]))
         if not args.include_chrY:
-            chromosomes.discard('chrY')
-#            chromosomes.discard('chr9')
+            chromosomes.discard("chrY")
+    #            chromosomes.discard('chr9')
     else:
         chromosomes = args.chromosomes.split(",")
 
     for chromosome in chromosomes:
-        print('Making predictions for chromosome: {}'.format(chromosome))
+        print("Making predictions for chromosome: {}".format(chromosome))
         t = time.time()
-        this_enh = enhancers.loc[enhancers['chr'] == chromosome, :].copy()
-        this_genes = genes.loc[genes['chr'] == chromosome, :].copy()
+        this_enh = enhancers.loc[enhancers["chr"] == chromosome, :].copy()
+        this_genes = genes.loc[genes["chr"] == chromosome, :].copy()
 
         this_chr = make_predictions(chromosome, this_enh, this_genes, args)
         all_putative_list.append(this_chr)
 
-        print('Completed chromosome: {}. Elapsed time: {} \n'.format(chromosome, time.time() - t))
+        print(
+            "Completed chromosome: {}. Elapsed time: {} \n".format(
+                chromosome, time.time() - t
+            )
+        )
 
     # Subset predictions
     print("Writing output files...")
     all_putative = pd.concat(all_putative_list)
-    all_putative['CellType'] = args.cellType
-    all_putative['hic_contact_squared'] = all_putative['hic_contact']**2
-    slim_cols = ['chr','start','end','name','TargetGene','TargetGeneTSS','CellType',args.score_column]
+    all_putative["CellType"] = args.cellType
+    all_putative["hic_contact_squared"] = all_putative["hic_contact"] ** 2
+    slim_cols = [
+        "chr",
+        "start",
+        "end",
+        "name",
+        "TargetGene",
+        "TargetGeneTSS",
+        "CellType",
+        args.score_column,
+    ]
     if args.run_all_genes:
-        all_positive = all_putative.iloc[np.logical_and.reduce((all_putative[args.score_column] > args.threshold, ~(all_putative['class'] == "promoter"))),:]
+        all_positive = all_putative.iloc[
+            np.logical_and.reduce(
+                (
+                    all_putative[args.score_column] > args.threshold,
+                    ~(all_putative["class"] == "promoter"),
+                )
+            ),
+            :,
+        ]
     else:
-        all_positive = all_putative.iloc[np.logical_and.reduce((all_putative.TargetGeneIsExpressed, all_putative[args.score_column] > args.threshold, ~(all_putative['class'] == "promoter"))),:]
+        all_positive = all_putative.iloc[
+            np.logical_and.reduce(
+                (
+                    all_putative.TargetGeneIsExpressed,
+                    all_putative[args.score_column] > args.threshold,
+                    ~(all_putative["class"] == "promoter"),
+                )
+            ),
+            :,
+        ]
 
-    
     if args.include_self_promoter:
-        self_promoter = all_putative.loc[all_putative['isSelfPromoter'],:]
+        self_promoter = all_putative.loc[all_putative["isSelfPromoter"], :]
         all_positive = pd.concat([all_positive, self_promoter]).drop_duplicates()
 
-    all_positive.to_csv(pred_file_full, sep="\t", index=False, header=True, float_format="%.6f")
-    all_positive[slim_cols].to_csv(pred_file_slim, sep="\t", index=False, header=True, float_format="%.6f")
+    all_positive.to_csv(
+        pred_file_full, sep="\t", index=False, header=True, float_format="%.6f"
+    )
+    all_positive[slim_cols].to_csv(
+        pred_file_slim, sep="\t", index=False, header=True, float_format="%.6f"
+    )
 
-    
     make_gene_prediction_stats(all_putative, args)
     write_connections_bedpe_format(all_positive, pred_file_bedpe, args.score_column)
-    
+
     if args.make_all_putative:
         if not args.use_hdf5:
-            all_putative.loc[all_putative.TargetGeneIsExpressed,:].to_csv(all_pred_file_expressed, sep="\t", index=False, header=True, compression="gzip", float_format="%.6f", na_rep="NaN")
-            all_putative.loc[~all_putative.TargetGeneIsExpressed,:].to_csv(all_pred_file_nonexpressed, sep="\t", index=False, header=True, compression="gzip", float_format="%.6f", na_rep="NaN")
+            all_putative.loc[all_putative.TargetGeneIsExpressed, :].to_csv(
+                all_pred_file_expressed,
+                sep="\t",
+                index=False,
+                header=True,
+                compression="gzip",
+                float_format="%.6f",
+                na_rep="NaN",
+            )
+            all_putative.loc[~all_putative.TargetGeneIsExpressed, :].to_csv(
+                all_pred_file_nonexpressed,
+                sep="\t",
+                index=False,
+                header=True,
+                compression="gzip",
+                float_format="%.6f",
+                na_rep="NaN",
+            )
         else:
-            all_pred_file_expressed = os.path.join(args.outdir, "EnhancerPredictionsAllPutative.h5")
-            all_pred_file_nonexpressed = os.path.join(args.outdir, "EnhancerPredictionsAllPutativeNonExpressedGenes.h5")
-            all_putative.loc[all_putative.TargetGeneIsExpressed,:].to_hdf(all_pred_file_expressed, key='predictions', complevel=9, mode='w')
-            all_putative.loc[~all_putative.TargetGeneIsExpressed,:].to_hdf(all_pred_file_nonexpressed, key='predictions', complevel=9, mode='w')
-   
+            all_pred_file_expressed = os.path.join(
+                args.outdir, "EnhancerPredictionsAllPutative.h5"
+            )
+            all_pred_file_nonexpressed = os.path.join(
+                args.outdir, "EnhancerPredictionsAllPutativeNonExpressedGenes.h5"
+            )
+            all_putative.loc[all_putative.TargetGeneIsExpressed, :].to_hdf(
+                all_pred_file_expressed, key="predictions", complevel=9, mode="w"
+            )
+            all_putative.loc[~all_putative.TargetGeneIsExpressed, :].to_hdf(
+                all_pred_file_nonexpressed, key="predictions", complevel=9, mode="w"
+            )
+
     test_variant_overlap(args, all_putative)
 
     print("Done.")
-    
+
+
 def validate_args(args):
-    if args.HiCdir and args.hic_type == 'juicebox':
-        assert args.hic_resolution is not None, 'HiC resolution must be provided if hic_type is juicebox'
+    if args.HiCdir and args.hic_type == "juicebox":
+        assert (
+            args.hic_resolution is not None
+        ), "HiC resolution must be provided if hic_type is juicebox"
 
     if not args.HiCdir:
-        print("WARNING: Hi-C directory not provided. Model will only compute ABC score using powerlaw!")
+        print(
+            "WARNING: Hi-C directory not provided. Model will only compute ABC score using powerlaw!"
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()
-    

--- a/workflow/scripts/predictor.py
+++ b/workflow/scripts/predictor.py
@@ -6,41 +6,59 @@ import time
 import pyranges as pr
 from hic import *
 
+
 def make_predictions(chromosome, enhancers, genes, args):
     pred = make_pred_table(chromosome, enhancers, genes, args)
     pred = annotate_predictions(pred, args.tss_slop)
     pred = add_powerlaw_to_predictions(pred, args)
 
-    #if Hi-C directory is not provided, only powerlaw model will be computed
+    # if Hi-C directory is not provided, only powerlaw model will be computed
     if args.HiCdir:
-        hic_file, hic_norm_file, hic_is_vc = get_hic_file(chromosome, args.HiCdir, hic_type = args.hic_type)
-        pred = add_hic_to_enh_gene_table(enhancers, genes, pred, hic_file, hic_norm_file, hic_is_vc, chromosome, args)
-        pred = compute_score(pred, [pred['activity_base'], pred['hic_contact_pl_scaled_adj']], "ABC")
-    
-    pred = compute_score(pred, [pred['activity_base'], pred['powerlaw_contact_reference']], "powerlaw")
+        hic_file, hic_norm_file, hic_is_vc = get_hic_file(
+            chromosome, args.HiCdir, hic_type=args.hic_type
+        )
+        pred = add_hic_to_enh_gene_table(
+            enhancers, genes, pred, hic_file, hic_norm_file, hic_is_vc, chromosome, args
+        )
+        pred = compute_score(
+            pred, [pred["activity_base"], pred["hic_contact_pl_scaled_adj"]], "ABC"
+        )
+
+    pred = compute_score(
+        pred, [pred["activity_base"], pred["powerlaw_contact_reference"]], "powerlaw"
+    )
 
     return pred
 
+
 def make_pred_table(chromosome, enh, genes, args):
-    print('Making putative predictions table...')
+    print("Making putative predictions table...")
     t = time.time()
-    enh['enh_midpoint'] = (enh['start'] + enh['end'])/2
-    enh['enh_idx'] = enh.index
-    genes['gene_idx'] = genes.index
+    enh["enh_midpoint"] = (enh["start"] + enh["end"]) / 2
+    enh["enh_idx"] = enh.index
+    genes["gene_idx"] = genes.index
     enh_pr = df_to_pyranges(enh)
-    genes_pr = df_to_pyranges(genes, start_col = 'TargetGeneTSS', end_col = 'TargetGeneTSS', start_slop=args.window, end_slop = args.window)
+    genes_pr = df_to_pyranges(
+        genes,
+        start_col="TargetGeneTSS",
+        end_col="TargetGeneTSS",
+        start_slop=args.window,
+        end_slop=args.window,
+    )
 
-    pred = enh_pr.join(genes_pr).df.drop(['Start_b','End_b','chr_b','Chromosome','Start','End'], axis = 1)
-    pred['distance'] = abs(pred['enh_midpoint'] - pred['TargetGeneTSS'])
-    pred = pred.loc[pred['distance'] < args.window,:] #for backwards compatability
+    pred = enh_pr.join(genes_pr).df.drop(
+        ["Start_b", "End_b", "chr_b", "Chromosome", "Start", "End"], axis=1
+    )
+    pred["distance"] = abs(pred["enh_midpoint"] - pred["TargetGeneTSS"])
+    pred = pred.loc[pred["distance"] < args.window, :]  # for backwards compatability
 
-    #without pyranges version
+    # without pyranges version
     # else:
     #     enh['temp_merge_key'] = 0
     #     genes['temp_merge_key'] = 0
 
-    #     #Make cartesian product and then subset to EG pairs within window. 
-    #     #TO DO: Replace with pyranges equivalent of bedtools intersect or GRanges overlaps 
+    #     #Make cartesian product and then subset to EG pairs within window.
+    #     #TO DO: Replace with pyranges equivalent of bedtools intersect or GRanges overlaps
     #     pred = pd.merge(enh, genes, on = 'temp_merge_key')
 
     #     pred['enh_midpoint'] = (pred['start'] + pred['end'])/2
@@ -52,149 +70,253 @@ def make_pred_table(chromosome, enh, genes, args):
 
     return pred
 
-def add_hic_to_enh_gene_table(enh, genes, pred, hic_file, hic_norm_file, hic_is_vc, chromosome, args):
-    print('Begin HiC')
-    HiC = load_hic(hic_file = hic_file, 
-                    hic_norm_file = hic_norm_file,
-                    hic_is_vc = hic_is_vc,
-                    hic_type = args.hic_type, 
-                    hic_resolution = args.hic_resolution, 
-                    tss_hic_contribution = args.tss_hic_contribution, 
-                    window = args.window, 
-                    min_window = 0, 
-                    gamma = args.hic_gamma,
-                    scale = args.hic_scale)
 
-    #Add hic to pred table
-    #At this point we have a table where each row is an enhancer/gene pair. 
-    #We need to add the corresponding HiC matrix entry.
-    #If the HiC is provided in juicebox format (ie constant resolution), then we can just merge using the indices
-    #But more generally we do not want to assume constant resolution. In this case hic should be provided in bedpe format
+def add_hic_to_enh_gene_table(
+    enh, genes, pred, hic_file, hic_norm_file, hic_is_vc, chromosome, args
+):
+    print("Begin HiC")
+    HiC = load_hic(
+        hic_file=hic_file,
+        hic_norm_file=hic_norm_file,
+        hic_is_vc=hic_is_vc,
+        hic_type=args.hic_type,
+        hic_resolution=args.hic_resolution,
+        tss_hic_contribution=args.tss_hic_contribution,
+        window=args.window,
+        min_window=0,
+        gamma=args.hic_gamma,
+        scale=args.hic_scale,
+    )
+
+    # Add hic to pred table
+    # At this point we have a table where each row is an enhancer/gene pair.
+    # We need to add the corresponding HiC matrix entry.
+    # If the HiC is provided in juicebox format (ie constant resolution), then we can just merge using the indices
+    # But more generally we do not want to assume constant resolution. In this case hic should be provided in bedpe format
 
     t = time.time()
     if args.hic_type == "bedpe":
-        #Use pyranges to compute overlaps between enhancers/genes and hic bedpe table
-        #Consider each range of the hic matrix separately - and merge each range into both enhancers and genes. 
-        #Then remerge on hic index
+        # Use pyranges to compute overlaps between enhancers/genes and hic bedpe table
+        # Consider each range of the hic matrix separately - and merge each range into both enhancers and genes.
+        # Then remerge on hic index
 
-        HiC['hic_idx'] = HiC.index
-        hic1 = df_to_pyranges(HiC, start_col='x1', end_col='x2', chr_col='chr1')
-        hic2 = df_to_pyranges(HiC, start_col='y1', end_col='y2', chr_col='chr2')
+        HiC["hic_idx"] = HiC.index
+        hic1 = df_to_pyranges(HiC, start_col="x1", end_col="x2", chr_col="chr1")
+        hic2 = df_to_pyranges(HiC, start_col="y1", end_col="y2", chr_col="chr2")
 
-        #Overlap in one direction
-        enh_hic1 = df_to_pyranges(enh, start_col = 'enh_midpoint', end_col = 'enh_midpoint', end_slop = 1).join(hic1).df
-        genes_hic2 = df_to_pyranges(genes, start_col = 'TargetGeneTSS', end_col = 'TargetGeneTSS', end_slop = 1).join(hic2).df
-        ovl12 = enh_hic1[['enh_idx','hic_idx','hic_contact']].merge(genes_hic2[['gene_idx', 'hic_idx']], on = 'hic_idx')
+        # Overlap in one direction
+        enh_hic1 = (
+            df_to_pyranges(
+                enh, start_col="enh_midpoint", end_col="enh_midpoint", end_slop=1
+            )
+            .join(hic1)
+            .df
+        )
+        genes_hic2 = (
+            df_to_pyranges(
+                genes, start_col="TargetGeneTSS", end_col="TargetGeneTSS", end_slop=1
+            )
+            .join(hic2)
+            .df
+        )
+        ovl12 = enh_hic1[["enh_idx", "hic_idx", "hic_contact"]].merge(
+            genes_hic2[["gene_idx", "hic_idx"]], on="hic_idx"
+        )
 
-        #Overlap in the other direction
-        enh_hic2 = df_to_pyranges(enh, start_col = 'enh_midpoint', end_col = 'enh_midpoint', end_slop = 1).join(hic2).df
-        genes_hic1 = df_to_pyranges(genes, start_col = 'TargetGeneTSS', end_col = 'TargetGeneTSS', end_slop = 1).join(hic1).df
-        ovl21 = enh_hic2[['enh_idx','hic_idx','hic_contact']].merge(genes_hic1[['gene_idx', 'hic_idx']], on = ['hic_idx'])
+        # Overlap in the other direction
+        enh_hic2 = (
+            df_to_pyranges(
+                enh, start_col="enh_midpoint", end_col="enh_midpoint", end_slop=1
+            )
+            .join(hic2)
+            .df
+        )
+        genes_hic1 = (
+            df_to_pyranges(
+                genes, start_col="TargetGeneTSS", end_col="TargetGeneTSS", end_slop=1
+            )
+            .join(hic1)
+            .df
+        )
+        ovl21 = enh_hic2[["enh_idx", "hic_idx", "hic_contact"]].merge(
+            genes_hic1[["gene_idx", "hic_idx"]], on=["hic_idx"]
+        )
 
-        #Concatenate both directions and merge into preditions
+        # Concatenate both directions and merge into preditions
         ovl = pd.concat([ovl12, ovl21]).drop_duplicates()
-        pred = pred.merge(ovl, on = ['enh_idx', 'gene_idx'], how = 'left')
-        pred.fillna(value={'hic_contact' : 0}, inplace=True)
-    elif args.hic_type == "juicebox" or args.hic_type == "avg" :
-        #Merge directly using indices
-        #Could also do this by indexing into the sparse matrix (instead of merge) but this seems to be slower
-        #Index into sparse matrix
-        #pred['hic_contact'] = [HiC[i,j] for (i,j) in pred[['enh_bin','tss_bin']].values.tolist()]
-        
-        pred['enh_bin'] = np.floor(pred['enh_midpoint'] / args.hic_resolution).astype(int)
-        pred['tss_bin'] = np.floor(pred['TargetGeneTSS'] / args.hic_resolution).astype(int)
+        pred = pred.merge(ovl, on=["enh_idx", "gene_idx"], how="left")
+        pred.fillna(value={"hic_contact": 0}, inplace=True)
+    elif args.hic_type == "juicebox" or args.hic_type == "avg":
+        # Merge directly using indices
+        # Could also do this by indexing into the sparse matrix (instead of merge) but this seems to be slower
+        # Index into sparse matrix
+        # pred['hic_contact'] = [HiC[i,j] for (i,j) in pred[['enh_bin','tss_bin']].values.tolist()]
+
+        pred["enh_bin"] = np.floor(pred["enh_midpoint"] / args.hic_resolution).astype(
+            int
+        )
+        pred["tss_bin"] = np.floor(pred["TargetGeneTSS"] / args.hic_resolution).astype(
+            int
+        )
         if not hic_is_vc:
-            #in this case the matrix is upper triangular.
+            # in this case the matrix is upper triangular.
             #
-            pred['bin1'] = np.amin(pred[['enh_bin', 'tss_bin']], axis = 1)
-            pred['bin2'] = np.amax(pred[['enh_bin', 'tss_bin']], axis = 1)
-            pred = pred.merge(HiC, how = 'left', on = ['bin1','bin2'])
-            pred.fillna(value={'hic_contact' : 0}, inplace=True)
+            pred["bin1"] = np.amin(pred[["enh_bin", "tss_bin"]], axis=1)
+            pred["bin2"] = np.amax(pred[["enh_bin", "tss_bin"]], axis=1)
+            pred = pred.merge(HiC, how="left", on=["bin1", "bin2"])
+            pred.fillna(value={"hic_contact": 0}, inplace=True)
         else:
             # The matrix is not triangular, its full
             # For VC assume genes correspond to rows and columns to enhancers
-            pred = pred.merge(HiC, how = 'left', left_on = ['tss_bin','enh_bin'], right_on=['bin1','bin2'])
+            pred = pred.merge(
+                HiC,
+                how="left",
+                left_on=["tss_bin", "enh_bin"],
+                right_on=["bin1", "bin2"],
+            )
 
-        pred.fillna(value={'hic_contact' : 0}, inplace=True)
+        pred.fillna(value={"hic_contact": 0}, inplace=True)
 
         # QC juicebox HiC
         pred = qc_hic(pred)
 
-    pred.drop(['x1','x2','y1','y2','bin1','bin2','enh_idx','gene_idx','hic_idx','enh_midpoint','tss_bin','enh_bin'], inplace=True, axis = 1, errors='ignore')
-        
-    print('HiC added to predictions table. Elapsed time: {}'.format(time.time() - t))
+    pred.drop(
+        [
+            "x1",
+            "x2",
+            "y1",
+            "y2",
+            "bin1",
+            "bin2",
+            "enh_idx",
+            "gene_idx",
+            "hic_idx",
+            "enh_midpoint",
+            "tss_bin",
+            "enh_bin",
+        ],
+        inplace=True,
+        axis=1,
+        errors="ignore",
+    )
+
+    print("HiC added to predictions table. Elapsed time: {}".format(time.time() - t))
     # Add powerlaw scaling
     pred = scale_hic_with_powerlaw(pred, args)
 
-    #Add pseudocount
+    # Add pseudocount
     pred = add_hic_pseudocount(pred, args)
 
     print("HiC Complete")
-    #print('Elapsed time: {}'.format(time.time() - t))
-
-    return(pred)
-
-def scale_hic_with_powerlaw(pred, args):
-    #Scale hic values to reference powerlaw
-
-    if not args.scale_hic_using_powerlaw:
-#        values = pred.loc[pred['hic_contact']==0].index.astype('int')
-#        pred.loc[values, 'hic_contact'] = pred.loc[values, 'powerlaw_contact']
-        pred['hic_contact_pl_scaled'] = pred['hic_contact']
-    else:
-        pred['hic_contact_pl_scaled'] = pred['hic_contact'] * (pred['powerlaw_contact_reference'] / pred['powerlaw_contact'])
-
-    return(pred)
-
-def add_powerlaw_to_predictions(pred, args):
-    pred['powerlaw_contact'] = get_powerlaw_at_distance(pred['distance'].values, args.hic_gamma, args.hic_scale)
-    pred['powerlaw_contact_reference'] = get_powerlaw_at_distance(pred['distance'].values, args.hic_gamma_reference, args.hic_scale)
+    # print('Elapsed time: {}'.format(time.time() - t))
 
     return pred
+
+
+def scale_hic_with_powerlaw(pred, args):
+    # Scale hic values to reference powerlaw
+
+    if not args.scale_hic_using_powerlaw:
+        #        values = pred.loc[pred['hic_contact']==0].index.astype('int')
+        #        pred.loc[values, 'hic_contact'] = pred.loc[values, 'powerlaw_contact']
+        pred["hic_contact_pl_scaled"] = pred["hic_contact"]
+    else:
+        pred["hic_contact_pl_scaled"] = pred["hic_contact"] * (
+            pred["powerlaw_contact_reference"] / pred["powerlaw_contact"]
+        )
+
+    return pred
+
+
+def add_powerlaw_to_predictions(pred, args):
+    pred["powerlaw_contact"] = get_powerlaw_at_distance(
+        pred["distance"].values, args.hic_gamma, args.hic_scale
+    )
+    pred["powerlaw_contact_reference"] = get_powerlaw_at_distance(
+        pred["distance"].values, args.hic_gamma_reference, args.hic_scale
+    )
+
+    return pred
+
 
 def add_hic_pseudocount(pred, args):
     # Add a pseudocount based on the powerlaw expected count at a given distance
 
-    powerlaw_fit = get_powerlaw_at_distance(pred['distance'].values, args.hic_gamma)
-    powerlaw_fit_at_ref = get_powerlaw_at_distance(args.hic_pseudocount_distance, args.hic_gamma)
-    
-    pseudocount = np.amin(pd.DataFrame({'a' : powerlaw_fit, 'b' : powerlaw_fit_at_ref}), axis = 1)
-    pred['hic_pseudocount'] = pseudocount
-    pred['hic_contact_pl_scaled_adj'] = pred['hic_contact_pl_scaled'] + pseudocount
+    powerlaw_fit = get_powerlaw_at_distance(pred["distance"].values, args.hic_gamma)
+    powerlaw_fit_at_ref = get_powerlaw_at_distance(
+        args.hic_pseudocount_distance, args.hic_gamma
+    )
 
-    return(pred)
-
-def qc_hic(pred, threshold = .01):
-    # Genes with insufficient hic coverage should get nan'd
-
-    summ = pred.loc[pred['isSelfPromoter'],:].groupby(['TargetGene']).agg({'hic_contact' : 'sum'})
-    bad_genes = summ.loc[summ['hic_contact'] < threshold,:].index
-
-    pred.loc[pred['TargetGene'].isin(bad_genes), 'hic_contact'] = np.nan
+    pseudocount = np.amin(
+        pd.DataFrame({"a": powerlaw_fit, "b": powerlaw_fit_at_ref}), axis=1
+    )
+    pred["hic_pseudocount"] = pseudocount
+    pred["hic_contact_pl_scaled_adj"] = pred["hic_contact_pl_scaled"] + pseudocount
 
     return pred
 
+
+def qc_hic(pred, threshold=0.01):
+    # Genes with insufficient hic coverage should get nan'd
+
+    summ = (
+        pred.loc[pred["isSelfPromoter"], :]
+        .groupby(["TargetGene"])
+        .agg({"hic_contact": "sum"})
+    )
+    bad_genes = summ.loc[summ["hic_contact"] < threshold, :].index
+
+    pred.loc[pred["TargetGene"].isin(bad_genes), "hic_contact"] = np.nan
+
+    return pred
+
+
 def compute_score(enhancers, product_terms, prefix):
+    scores = np.column_stack(product_terms).prod(axis=1)
 
-    scores = np.column_stack(product_terms).prod(axis = 1)
+    enhancers[prefix + ".Score.Numerator"] = scores
+    enhancers[prefix + ".Score"] = enhancers[
+        prefix + ".Score.Numerator"
+    ] / enhancers.groupby(["TargetGene", "TargetGeneTSS"])[
+        prefix + ".Score.Numerator"
+    ].transform(
+        "sum"
+    )
 
-    enhancers[prefix + '.Score.Numerator'] = scores
-    enhancers[prefix + '.Score'] = enhancers[prefix + '.Score.Numerator'] / enhancers.groupby(['TargetGene','TargetGeneTSS'])[prefix + '.Score.Numerator'].transform('sum')
+    return enhancers
 
-    return(enhancers)
 
 def annotate_predictions(pred, tss_slop=500):
-    #TO DO: Add is self genic
-    pred['isSelfPromoter'] = np.logical_and.reduce((pred['class'] == 'promoter' , pred.start - tss_slop < pred.TargetGeneTSS, pred.end + tss_slop > pred.TargetGeneTSS))
+    # TO DO: Add is self genic
+    pred["isSelfPromoter"] = np.logical_and.reduce(
+        (
+            pred["class"] == "promoter",
+            pred.start - tss_slop < pred.TargetGeneTSS,
+            pred.end + tss_slop > pred.TargetGeneTSS,
+        )
+    )
 
-    return(pred)
+    return pred
+
 
 def make_gene_prediction_stats(pred, args):
-    summ1 = pred.groupby(['chr','TargetGene','TargetGeneTSS']).agg({'TargetGeneIsExpressed' : lambda x: set(x).pop(), args.score_column : lambda x: all(np.isnan(x)) ,  'name' : 'count'})
-    summ1.columns = ['geneIsExpressed', 'geneFailed','nEnhancersConsidered']
+    summ1 = pred.groupby(["chr", "TargetGene", "TargetGeneTSS"]).agg(
+        {
+            "TargetGeneIsExpressed": lambda x: set(x).pop(),
+            args.score_column: lambda x: all(np.isnan(x)),
+            "name": "count",
+        }
+    )
+    summ1.columns = ["geneIsExpressed", "geneFailed", "nEnhancersConsidered"]
 
-    summ2 = pred.loc[pred['class'] != 'promoter',:].groupby(['chr','TargetGene','TargetGeneTSS']).agg({args.score_column : lambda x: sum(x > args.threshold)})
-    summ2.columns = ['nDistalEnhancersPredicted']
+    summ2 = (
+        pred.loc[pred["class"] != "promoter", :]
+        .groupby(["chr", "TargetGene", "TargetGeneTSS"])
+        .agg({args.score_column: lambda x: sum(x > args.threshold)})
+    )
+    summ2.columns = ["nDistalEnhancersPredicted"]
     summ1 = summ1.merge(summ2, left_index=True, right_index=True)
 
-    summ1.to_csv(os.path.join(args.outdir, "GenePredictionStats.txt"), sep="\t", index=True)
+    summ1.to_csv(
+        os.path.join(args.outdir, "GenePredictionStats.txt"), sep="\t", index=True
+    )

--- a/workflow/scripts/run.neighborhoods.py
+++ b/workflow/scripts/run.neighborhoods.py
@@ -3,95 +3,193 @@ import os
 from neighborhoods import *
 from subprocess import getoutput
 
+
 def parseargs(required_args=True):
-    class formatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter):
+    class formatter(
+        argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter
+    ):
         pass
 
-    epilog = ("")
-    parser = argparse.ArgumentParser(description='Run neighborhood for a given cell type',
-                                     epilog=epilog,
-                                     formatter_class=formatter)
-    readable = argparse.FileType('r')
-    
-    parser.add_argument('--candidate_enhancer_regions', required=required_args, help="Bed file containing candidate_enhancer_regions")
-    parser.add_argument('--outdir', required=required_args, help="Directory to write Neighborhood files to.")
-    
-    #genes
-    parser.add_argument('--genes', required=required_args, help="bed file with gene annotations. Must be in bed-6 format. Will be used to assign TSS to genes.")
-    parser.add_argument('--genes_for_class_assignment', default=None, help="bed gene annotations for assigning elements to promoter/genic/intergenic classes. Will not be used for TSS definition")
-    parser.add_argument('--ubiquitously_expressed_genes', default=None, help="File listing ubiquitously expressed genes. These will be flagged by the model, but this annotation does not affect model predictions")
-    parser.add_argument('--gene_name_annotations', default="symbol", help="Comma delimited string of names corresponding to the gene identifiers present in the name field of the gene annotation bed file")
-    parser.add_argument('--primary_gene_identifier', default="symbol", help="Primary identifier used to identify genes. Must be present in gene_name_annotations. The primary identifier must be unique")
-    parser.add_argument('--skip_gene_counts', action="store_true", help="Do not count over genes or gene bodies. Will not produce GeneList.txt. Do not use switch if intending to run Predictions")
+    epilog = ""
+    parser = argparse.ArgumentParser(
+        description="Run neighborhood for a given cell type",
+        epilog=epilog,
+        formatter_class=formatter,
+    )
+    readable = argparse.FileType("r")
 
-    #epi 
-    parser.add_argument('--H3K27ac', default="", nargs='?', help="Comma delimited string of H3K27ac .bam files")
-    parser.add_argument('--DHS', default="", nargs='?', help="Comma delimited string of DHS .bam files. Either ATAC or DHS must be provided")
-    parser.add_argument('--ATAC', default="", nargs='?', help="Comma delimited string of ATAC .bam files. Either ATAC or DHS must be provided")
-    parser.add_argument('--default_accessibility_feature', default=None, nargs='?', help="If both ATAC and DHS are provided, this flag must be set to either 'DHS' or 'ATAC' signifying which datatype to use in computing activity")
-    parser.add_argument('--expression_table', default="", nargs='?', help="Comma delimited string of gene expression files")
-    parser.add_argument('--qnorm', default=None, help="Quantile normalization reference file")
+    parser.add_argument(
+        "--candidate_enhancer_regions",
+        required=required_args,
+        help="Bed file containing candidate_enhancer_regions",
+    )
+    parser.add_argument(
+        "--outdir",
+        required=required_args,
+        help="Directory to write Neighborhood files to.",
+    )
 
-    #Other
-    parser.add_argument('--tss_slop_for_class_assignment', default=500, type=int, help="Consider an element a promoter if it is within this many bp of a tss")
-    parser.add_argument('--skip_rpkm_quantile', action="store_true", help="Do not compute RPKM and quantiles in EnhancerList.txt")
-    parser.add_argument('--use_secondary_counting_method', action="store_true", help="Use a slightly slower way to count bam over bed. Also requires more memory. But is more stable")
-    parser.add_argument('--chrom_sizes', required=required_args, help="Genome file listing chromosome sizes. Also requires associated .bed file")
-    parser.add_argument('--enhancer_class_override', default=None, help="Annotation file to override enhancer class assignment")
-    parser.add_argument('--supplementary_features', default=None, help="Additional features to count over regions")
-    parser.add_argument('--cellType', default=None, help="Name of cell type")
+    # genes
+    parser.add_argument(
+        "--genes",
+        required=required_args,
+        help="bed file with gene annotations. Must be in bed-6 format. Will be used to assign TSS to genes.",
+    )
+    parser.add_argument(
+        "--genes_for_class_assignment",
+        default=None,
+        help="bed gene annotations for assigning elements to promoter/genic/intergenic classes. Will not be used for TSS definition",
+    )
+    parser.add_argument(
+        "--ubiquitously_expressed_genes",
+        default=None,
+        help="File listing ubiquitously expressed genes. These will be flagged by the model, but this annotation does not affect model predictions",
+    )
+    parser.add_argument(
+        "--gene_name_annotations",
+        default="symbol",
+        help="Comma delimited string of names corresponding to the gene identifiers present in the name field of the gene annotation bed file",
+    )
+    parser.add_argument(
+        "--primary_gene_identifier",
+        default="symbol",
+        help="Primary identifier used to identify genes. Must be present in gene_name_annotations. The primary identifier must be unique",
+    )
+    parser.add_argument(
+        "--skip_gene_counts",
+        action="store_true",
+        help="Do not count over genes or gene bodies. Will not produce GeneList.txt. Do not use switch if intending to run Predictions",
+    )
+
+    # epi
+    parser.add_argument(
+        "--H3K27ac",
+        default="",
+        nargs="?",
+        help="Comma delimited string of H3K27ac .bam files",
+    )
+    parser.add_argument(
+        "--DHS",
+        default="",
+        nargs="?",
+        help="Comma delimited string of DHS .bam files. Either ATAC or DHS must be provided",
+    )
+    parser.add_argument(
+        "--ATAC",
+        default="",
+        nargs="?",
+        help="Comma delimited string of ATAC .bam files. Either ATAC or DHS must be provided",
+    )
+    parser.add_argument(
+        "--default_accessibility_feature",
+        default=None,
+        nargs="?",
+        help="If both ATAC and DHS are provided, this flag must be set to either 'DHS' or 'ATAC' signifying which datatype to use in computing activity",
+    )
+    parser.add_argument(
+        "--expression_table",
+        default="",
+        nargs="?",
+        help="Comma delimited string of gene expression files",
+    )
+    parser.add_argument(
+        "--qnorm", default=None, help="Quantile normalization reference file"
+    )
+
+    # Other
+    parser.add_argument(
+        "--tss_slop_for_class_assignment",
+        default=500,
+        type=int,
+        help="Consider an element a promoter if it is within this many bp of a tss",
+    )
+    parser.add_argument(
+        "--skip_rpkm_quantile",
+        action="store_true",
+        help="Do not compute RPKM and quantiles in EnhancerList.txt",
+    )
+    parser.add_argument(
+        "--use_secondary_counting_method",
+        action="store_true",
+        help="Use a slightly slower way to count bam over bed. Also requires more memory. But is more stable",
+    )
+    parser.add_argument(
+        "--chrom_sizes",
+        required=required_args,
+        help="Genome file listing chromosome sizes. Also requires associated .bed file",
+    )
+    parser.add_argument(
+        "--enhancer_class_override",
+        default=None,
+        help="Annotation file to override enhancer class assignment",
+    )
+    parser.add_argument(
+        "--supplementary_features",
+        default=None,
+        help="Additional features to count over regions",
+    )
+    parser.add_argument("--cellType", default=None, help="Name of cell type")
 
     # replace textio wrapper returned by argparse with actual filename
     args = parser.parse_args()
     for name, val in vars(args).items():
-        if hasattr(val, 'name'):
+        if hasattr(val, "name"):
             setattr(args, name, val.name)
     print(args)
     return args
+
 
 def processCellType(args):
     params = parse_params_file(args)
 
     os.makedirs(args.outdir, exist_ok=True)
 
-    #Setup Genes
-    genes, genes_for_class_assignment = load_genes(file = args.genes, 
-                                                ue_file = args.ubiquitously_expressed_genes,
-                                                chrom_sizes = args.chrom_sizes,
-                                                outdir = args.outdir, 
-                                                expression_table_list = params["expression_table"], 
-                                                gene_id_names = args.gene_name_annotations, 
-                                                primary_id = args.primary_gene_identifier,
-                                                cellType = args.cellType,
-                                                class_gene_file = args.genes_for_class_assignment)
+    # Setup Genes
+    genes, genes_for_class_assignment = load_genes(
+        file=args.genes,
+        ue_file=args.ubiquitously_expressed_genes,
+        chrom_sizes=args.chrom_sizes,
+        outdir=args.outdir,
+        expression_table_list=params["expression_table"],
+        gene_id_names=args.gene_name_annotations,
+        primary_id=args.primary_gene_identifier,
+        cellType=args.cellType,
+        class_gene_file=args.genes_for_class_assignment,
+    )
 
     if not args.skip_gene_counts:
-        annotate_genes_with_features(genes = genes, 
-                                        genome_sizes = args.chrom_sizes, 
-                                        use_fast_count = (not args.use_secondary_counting_method),
-                                        default_accessibility_feature = params['default_accessibility_feature'],
-                                        features = params['features'],
-                                        outdir = args.outdir)
+        annotate_genes_with_features(
+            genes=genes,
+            genome_sizes=args.chrom_sizes,
+            use_fast_count=(not args.use_secondary_counting_method),
+            default_accessibility_feature=params["default_accessibility_feature"],
+            features=params["features"],
+            outdir=args.outdir,
+        )
 
-    #Setup Candidate Enhancers
-    load_enhancers(genes=genes_for_class_assignment, 
-                    genome_sizes=args.chrom_sizes, 
-                    candidate_peaks=args.candidate_enhancer_regions, 
-                    skip_rpkm_quantile=args.skip_rpkm_quantile, 
-                    qnorm = args.qnorm,
-                    tss_slop_for_class_assignment=args.tss_slop_for_class_assignment,
-                    use_fast_count = (not args.use_secondary_counting_method),
-                    default_accessibility_feature = params['default_accessibility_feature'],
-                    features = params['features'],
-                    cellType = args.cellType,
-                    class_override_file = args.enhancer_class_override,
-                    outdir = args.outdir)
+    # Setup Candidate Enhancers
+    load_enhancers(
+        genes=genes_for_class_assignment,
+        genome_sizes=args.chrom_sizes,
+        candidate_peaks=args.candidate_enhancer_regions,
+        skip_rpkm_quantile=args.skip_rpkm_quantile,
+        qnorm=args.qnorm,
+        tss_slop_for_class_assignment=args.tss_slop_for_class_assignment,
+        use_fast_count=(not args.use_secondary_counting_method),
+        default_accessibility_feature=params["default_accessibility_feature"],
+        features=params["features"],
+        cellType=args.cellType,
+        class_override_file=args.enhancer_class_override,
+        outdir=args.outdir,
+    )
 
-    print('Neighborhoods Complete! \n')
+    print("Neighborhoods Complete! \n")
+
 
 def main(args):
     processCellType(args)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     args = parseargs()
     main(args)

--- a/workflow/scripts/tools.py
+++ b/workflow/scripts/tools.py
@@ -8,21 +8,23 @@ import pyranges as pr
 
 # setting this to raise makes sure that any dangerous assignments to pandas
 # dataframe slices/subsets error rather than warn
-pd.set_option('mode.chained_assignment', 'raise')
+pd.set_option("mode.chained_assignment", "raise")
+
 
 def run_command(command, **args):
     print("Running command: " + command)
     return check_call(command, shell=True, **args)
 
+
 def write_connections_bedpe_format(pred, outfile, score_column):
-    #Output a 2d annotation file with EP connections in bedpe format for loading into IGV
+    # Output a 2d annotation file with EP connections in bedpe format for loading into IGV
     pred = pred.drop_duplicates()
 
     towrite = pd.DataFrame()
 
     towrite["chr1"] = pred["chr"]
-    towrite["x1"] = pred['start']
-    towrite["x2"] = pred['end']
+    towrite["x1"] = pred["start"]
+    towrite["x2"] = pred["end"]
     towrite["chr2"] = pred["chr"]
     towrite["y1"] = pred["TargetGeneTSS"]
     towrite["y2"] = pred["TargetGeneTSS"]
@@ -31,26 +33,37 @@ def write_connections_bedpe_format(pred, outfile, score_column):
     towrite["strand1"] = "."
     towrite["strand2"] = "."
 
-    towrite.to_csv(outfile, header=False, index=False, sep = "\t")
+    towrite.to_csv(outfile, header=False, index=False, sep="\t")
+
 
 def determine_expressed_genes(genes, expression_cutoff, activity_quantile_cutoff):
-    #Evaluate whether a gene should be considered 'expressed' so that it runs through the model
+    # Evaluate whether a gene should be considered 'expressed' so that it runs through the model
 
-    #A gene is runnable if:
-    #It is expressed OR (there is no expression AND its promoter has high activity)
+    # A gene is runnable if:
+    # It is expressed OR (there is no expression AND its promoter has high activity)
 
-    genes['isExpressed'] = np.logical_or(genes.Expression >= expression_cutoff, np.logical_and(np.isnan(genes.Expression), genes.PromoterActivityQuantile >= activity_quantile_cutoff))
+    genes["isExpressed"] = np.logical_or(
+        genes.Expression >= expression_cutoff,
+        np.logical_and(
+            np.isnan(genes.Expression),
+            genes.PromoterActivityQuantile >= activity_quantile_cutoff,
+        ),
+    )
 
-    return(genes)
+    return genes
+
 
 def write_params(args, file):
-    with open(file, 'w') as outfile:
+    with open(file, "w") as outfile:
         for arg in vars(args):
             outfile.write(arg + " " + str(getattr(args, arg)) + "\n")
 
-def df_to_pyranges(df, start_col='start', end_col='end', chr_col='chr', start_slop=0, end_slop=0):
-    df['Chromosome'] = df[chr_col]
-    df['Start'] = df[start_col] - start_slop
-    df['End'] = df[end_col] + end_slop
 
-    return(pr.PyRanges(df))
+def df_to_pyranges(
+    df, start_col="start", end_col="end", chr_col="chr", start_slop=0, end_slop=0
+):
+    df["Chromosome"] = df[chr_col]
+    df["Start"] = df[start_col] - start_slop
+    df["End"] = df[end_col] + end_slop
+
+    return pr.PyRanges(df)


### PR DESCRIPTION
pip install black
Then ran black on entire directory.

Autoformat has a lot of benefits. It keeps a standardized format for python files, making code a lot more readable. 

We add a step in CircleCI to verify that all files have passed the linter (which ensures formatting matches python black).

## Test Plan
chr22 test still passes after autoformat

![image](https://github.com/broadinstitute/ABC-Enhancer-Gene-Prediction/assets/10254642/630576dd-d946-411e-b28c-bb429670103f)
