### PR TITLE
update QC plots

### DIFF
--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -3,6 +3,7 @@ rule gen_qc_plots:
 		candidateRegions = os.path.join(RESULTS_DIR, "{biosample}", "Peaks", "macs2_peaks.narrowPeak.sorted.candidateRegions.bed"),
 		neighborhoodDirectory = directory(os.path.join(RESULTS_DIR, "{biosample}", "Neighborhoods")),
 		enhPredictionsFull = os.path.join(RESULTS_DIR, "{biosample}", "Predictions", "EnhancerPredictionsFull.tsv"),
+		chrom_sizes = config['chrom_sizes'],
 		powerlaw_params_tsv = get_hic_powerlaw_fit_file
 	params:
 		output_dir = os.path.join(RESULTS_DIR, "{biosample}", "Metrics")
@@ -17,5 +18,6 @@ rule gen_qc_plots:
 			--macs_peaks {input.candidateRegions} \
 			--neighborhood_outdir {input.neighborhoodDirectory} \
 			--preds_file {input.enhPredictionsFull} \
+			--chrom_sizes {input.chrom_sizes} \
 			--powerlaw_params_tsv {input.powerlaw_params_tsv}
 		"""

--- a/workflow/scripts/grabMetrics.py
+++ b/workflow/scripts/grabMetrics.py
@@ -1,38 +1,43 @@
 #! bin/python3
-import sys
-from metrics import *
-from tools import *
-import pandas as pd
-import glob
 import argparse
-import pickle
+import glob
 import os.path
+import pickle
+
+import pandas as pd
+from metrics import GrabQCMetrics, HiCQC, NeighborhoodFileQC, PeakFileQC
 
 
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--macs_peaks",
+        required=True,
         help="narrowPeak file output by macs2. (eg. /users/kmualim/K562/macs2_peaks.narrowPeak)",
     )
-    parser.add_argument("--preds_file", help="Prediction file output by ABC")
-    parser.add_argument("--neighborhood_outdir", help="Neighborhood Directory")
+    parser.add_argument(
+        "--preds_file", required=True, help="Prediction file output by ABC"
+    )
+    parser.add_argument(
+        "--neighborhood_outdir", required=True, help="Neighborhood Directory"
+    )
+    parser.add_argument("--chrom_sizes", required=True, help="Chromosome sizes file")
+    parser.add_argument("--outdir", required=True, help="Predictions Directory")
     parser.add_argument(
         "--powerlaw_params_tsv",
         type=str,
         help="TSV file containing gamma/scale values according to powerlaw fit",
     )
-    parser.add_argument("--outdir", help="Predictions Directory")
     args = parser.parse_args()
     return args
 
 
 def generateQCMetrics(args):
-    # prediction = "{}/EnhancerPredictionsFull.txt".format(args.preds_outdir)
+    chrom_order = pd.read_csv(args.chrom_sizes, sep="\t", header=None)[0].tolist()
     # read prediction file
     prediction_df = pd.read_csv(args.preds_file, sep="\t")
     # Generate QC Summary.txt in Predictions Directory
-    pred_metrics = GrabQCMetrics(prediction_df, args.outdir)
+    pred_metrics = GrabQCMetrics(prediction_df, chrom_order, args.outdir)
     # Generate PeakFileQCSummary.txt in Peaks Directory#
     pred_metrics = PeakFileQC(pred_metrics, args.macs_peaks, args.outdir)
     # Appends Percentage Counts in Promoters into PeakFileQCSummary.txt

--- a/workflow/scripts/predict.py
+++ b/workflow/scripts/predict.py
@@ -4,14 +4,14 @@ import os.path
 import sys
 import time
 import traceback
+from typing import Dict
 
 import numpy as np
-from typing import Dict
 import pandas as pd
+from compute_powerlaw_fit_from_hic import do_powerlaw_fit, load_hic_for_powerlaw
 from getVariantOverlap import *
 from predictor import *
 from tools import *
-from compute_powerlaw_fit_from_hic import load_hic_for_powerlaw, do_powerlaw_fit
 
 
 def get_model_argument_parser():
@@ -212,7 +212,17 @@ def main():
     # TO DO
     # Think about which columns to include
     enhancers = enhancers_full.loc[
-        :, ["chr", "start", "end", "name", "class", "activity_base", "normalized_dhs"]
+        :,
+        [
+            "chr",
+            "start",
+            "end",
+            "name",
+            "class",
+            "activity_base",
+            "normalized_dhs",
+            "normalized_h3K27ac",
+        ],
     ]
     enhancers["activity_base_squared"] = enhancers["activity_base"] ** 2
     # Initialize Prediction files


### PR DESCRIPTION
Update QC plots based on feedback from 8/3 EP Benchmarking meeting.

Also show normalized_h3k27ac column in prediction output

## Test Plan
normalized_h3K27ac shows up in output
```
(base) [atan5133@sh03-ln05 login /oak/stanford/groups/engreitz/Users/atan5133/ABC-Enhancer-Gene-Prediction/results/K562_chr22/Predictions]$ zcat EnhancerPredictionsAllPutative.txt.gz | head -2
chr     start   end     name    class   activity_base   normalized_dhs  normalized_h3K27ac      activity_base_squared TargetGene      TargetGeneTSS   TargetGeneExpression    TargetGenePromoterActivityQuantile      TargetGeneIsExpressed normalized_dhs_b        distance        isSelfPromoter  powerlaw_contact        powerlaw_contact_reference    hic_contact     juicebox_contact_values hic_contact_pl_scaled   hic_pseudocount hic_contact_pl_scaled_adj     ABC.Score.Numerator     ABC.Score       powerlaw.Score.Numerator        powerlaw.Score  CellType      hic_contact_squared
chr22   11604655        11605155        intergenic|chr22:11604655-11605155      intergenic      7.408446     8.749381 6.273023        54.885072       TPTEP1  16601910        NaN     0.805808        True    0.735027 (base)
```

Plots
Now uses log10 and density
![image](https://github.com/broadinstitute/ABC-Enhancer-Gene-Prediction/assets/10254642/1ab8ba16-8ed3-4cce-a0cb-ee500321169c)

Bar Plot Sorted by Chromosome 
![image](https://github.com/broadinstitute/ABC-Enhancer-Gene-Prediction/assets/10254642/bd74c3b8-0cb0-4872-997c-1886047f0d53)

Remove density curve (for this and Genes per enhancer plot)
![image](https://github.com/broadinstitute/ABC-Enhancer-Gene-Prediction/assets/10254642/024ae708-d6fe-4284-88f0-ba310ed5d15f)





