### PR TITLE
fix broken multi-bam support for candidate regions

### DIFF
--- a/workflow/scripts/makeCandidateRegions.py
+++ b/workflow/scripts/makeCandidateRegions.py
@@ -1,9 +1,6 @@
-import pandas as pd
-import numpy as np
 import argparse
 import os
-from peaks import *
-import traceback
+from peaks import make_candidate_regions_from_summits, make_candidate_regions_from_peaks
 from tools import write_params
 
 
@@ -83,8 +80,7 @@ def processCellType(args):
     if not args.ignoreSummits:
         make_candidate_regions_from_summits(
             macs_peaks=args.narrowPeak,
-            # accessibility_file = args.bam,
-            accessibility_file=args.bam.split(","),
+            accessibility_file=args.bam,
             genome_sizes=args.chrom_sizes,
             regions_includelist=args.regions_includelist,
             regions_blocklist=args.regions_blocklist,

--- a/workflow/scripts/peaks.py
+++ b/workflow/scripts/peaks.py
@@ -1,9 +1,8 @@
 import pandas as pd
-import numpy as np
 import os
 import os.path
-from tools import *
-from neighborhoods import *
+from subprocess import PIPE, Popen
+from neighborhoods import run_count_reads
 
 
 def make_candidate_regions_from_summits(
@@ -21,17 +20,13 @@ def make_candidate_regions_from_summits(
     outfile = os.path.join(
         outdir, os.path.basename(macs_peaks) + ".candidateRegions.bed"
     )  # output file name for candidateRegions.bed
-    raw_counts_out = []  # initialize list for output file names
-    for access_in in accessibility_file:  # loop through input accessibilty files
-        raw_counts_out.append(
-            os.path.join(
-                outdir,
-                os.path.basename(macs_peaks)
-                + "."
-                + os.path.basename(access_in)
-                + ".Counts.bed",
-            )
-        )  # add corresponding output file name
+    raw_counts_outfile = os.path.join(
+        outdir,
+        os.path.basename(macs_peaks)
+        + "."
+        + os.path.basename(accessibility_file)
+        + ".Counts.bed",
+    )
     if regions_includelist:
         includelist_command = "(bedtools intersect -a {regions_includelist} -b {genome_sizes}.bed -wa | cut -f 1-3 && cat) |"
     else:
@@ -48,19 +43,18 @@ def make_candidate_regions_from_summits(
     # run_count_reads(accessibility_file, raw_counts_outfile, macs_peaks, genome_sizes, use_fast_count=True)
 
     # 1. Count DHS/ATAC reads in candidate regions for all accessibility files provided, and return the filename of the average # reads
-    reads_out = count_reads_over_peaks(
+    run_count_reads(
         accessibility_file,
-        raw_counts_out,
+        raw_counts_outfile,
         macs_peaks,
         genome_sizes,
-        outdir,
         use_fast_count=True,
     )
 
     # 2. Take top N regions, get summits, extend summits, merge, remove blocklist, add includelist, sort and merge
     # use -sorted in intersect command? Not worth it, both files are small
     command = (
-        "bedtools sort -i {reads_out} -faidx {genome_sizes} | bedtools merge -i stdin -c 4 -o max | sort -nr -k 4 | head -n {n_enhancers} |"
+        "bedtools sort -i {raw_counts_outfile} -faidx {genome_sizes} | bedtools merge -i stdin -c 4 -o max | sort -nr -k 4 | head -n {n_enhancers} |"
         + "bedtools intersect -b stdin -a {macs_peaks} -wa |"
         + 'awk \'{{print $1 "\\t" $2 + $10 "\\t" $2 + $10}}\' |'
         + "bedtools slop -i stdin -b {peak_extend} -g {genome_sizes} |"
@@ -97,18 +91,13 @@ def make_candidate_regions_from_peaks(
     outfile = os.path.join(
         outdir, os.path.basename(macs_peaks) + ".candidateRegions.bed"
     )
-    raw_counts_out = []  # initialize list for output file names
-    for access_in in accessibility_file:  # loop through input accessibilty files
-        raw_counts_out.append(
-            os.path.join(
-                outdir,
-                os.path.basename(macs_peaks)
-                + "."
-                + os.path.basename(access_in)
-                + ".Counts.bed",
-            )
-        )  # add corresponding output file name
-
+    raw_counts_outfile = os.path.join(
+        outdir,
+        os.path.basename(macs_peaks)
+        + "."
+        + os.path.basename(accessibility_file)
+        + ".Counts.bed",
+    )
     if regions_includelist:
         includelist_command = "(bedtools intersect -a {regions_includelist} -b {genome_sizes}.bed -wa | cut -f 1-3 && cat) |"
     else:
@@ -122,19 +111,18 @@ def make_candidate_regions_from_peaks(
         blocklist_command = ""
 
     # 1. Count DHS/ATAC reads in candidate regions
-    reads_out = count_reads_over_peaks(
+    run_count_reads(
         accessibility_file,
-        raw_counts_out,
+        raw_counts_outfile,
         macs_peaks,
         genome_sizes,
-        outdir,
         use_fast_count=True,
     )
 
     # 2. Take top N regions, extend peaks (min size 500), merge, remove blocklist, add includelist, sort and merge
     # use -sorted in intersect command? Not worth it, both files are small
     command = (
-        "bedtools sort -i {reads_out} -faidx {genome_sizes} | bedtools merge -i stdin -c 4 -o max | sort -nr -k 4 | head -n {n_enhancers} |"
+        "bedtools sort -i {raw_counts_outfile} -faidx {genome_sizes} | bedtools merge -i stdin -c 4 -o max | sort -nr -k 4 | head -n {n_enhancers} |"
         + "bedtools intersect -b stdin -a {macs_peaks} -wa |"
         + "bedtools slop -i stdin -b {peak_extend} -g {genome_sizes} |"
         + 'awk \'{{ l=$3-$2; if (l < {minPeakWidth}) {{ $2 = $2 - int(({minPeakWidth}-l)/2); $3 = $3 + int(({minPeakWidth}-l)/2) }} print $1 "\\t" $2 "\\t" $3}}\' |'
@@ -156,33 +144,3 @@ def make_candidate_regions_from_peaks(
         raise RuntimeError("Command failed.")
 
     return stdoutdata
-
-
-# count reads over however many DHS files and return average
-def count_reads_over_peaks(
-    accessibility_file,
-    raw_counts_out,
-    macs_peaks,
-    genome_sizes,
-    outdir,
-    use_fast_count=True,
-):
-    for access_in, counts_out in zip(accessibility_file, raw_counts_out):
-        run_count_reads(access_in, counts_out, macs_peaks, genome_sizes, use_fast_count)
-        nFiles = len(raw_counts_out)
-
-    if nFiles > 1:
-        avg_out = os.path.join(
-            outdir, os.path.basename(macs_peaks) + ".averageAccessibility.Counts.bed"
-        )
-        df1 = pd.read_csv(raw_counts_out[0], sep="\t", header=None)
-        totalCounts = df1[3]
-        for i in range(1, nFiles):
-            dfx = pd.read_csv(raw_counts_out[i], sep="\t", header=None, usecols=[3])
-            print(len(dfx))
-            df1[3] = df1[3].add(dfx[3])
-        df1[3] = df1[3] / nFiles
-        df1.to_csv(avg_out, header=None, index=None, sep="\t")
-        return avg_out
-    else:
-        return raw_counts_out[0]


### PR DESCRIPTION
Seems like someone previously tried to incorporate passing in multiple BAM files to candidate regions. That new feature addition wasn't quite complete b/c it would break the code if the scripts was run with --ignore_summits, which goes through a different code path. Since I'm not aware of any use case of multi-bam files, and the feature added was incomplete, let's just remove it for now and revert it back to [how the main branch does it](https://github.com/broadinstitute/ABC-Enhancer-Gene-Prediction/blob/master/src/peaks.py)

I also cleaned up the candidate region file imports

## Test Plan 

Existing tests pass