### PR TITLE
double activity for sex chrom

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,13 +28,14 @@ jobs:
           name: Install basic OS pkgs
           command: apt-get update && apt-get -y install curl vim
       - run:
+          name: Run Linter (python black)
+          command: |
+            mamba install black
+            black . --check
+      - run:
           name: Install abc-env
           command: |
             mamba env create -f workflow/envs/abcenv.yml
-            mamba install black
-      - run:
-          name: Run Linter (python black)
-          command: black . --check
       - run:
           name: Run tests
           command: |

--- a/workflow/scripts/neighborhoods.py
+++ b/workflow/scripts/neighborhoods.py
@@ -426,7 +426,17 @@ def run_count_reads(target, output, bed_file, genome_sizes, use_fast_count):
         raise ValueError(
             "File {} name was not in .bam, .tagAlign.gz, .bw".format(target)
         )
+    double_sex_chrom_counts(output)
+    
 
+def double_sex_chrom_counts(output):
+    # Double the count values for X chromosomes to make it seem like it has
+    # 2 copies
+    awk_command = r'''awk 'BEGIN {FS=OFS="\t"} substr($1, length($1)) == "X" { $4 *= 2 } 1' '''
+    file_creation_command = f"{output} > {output}.tmp && mv {output}.tmp {output}"
+    p = check_call(awk_command + file_creation_command, shell=True)
+    if p != 0:
+        print(p.stderr)
 
 def count_bam(
     bamfile, bed_file, output, genome_sizes, use_fast_count=True, verbose=True

--- a/workflow/scripts/neighborhoods.py
+++ b/workflow/scripts/neighborhoods.py
@@ -427,16 +427,17 @@ def run_count_reads(target, output, bed_file, genome_sizes, use_fast_count):
             "File {} name was not in .bam, .tagAlign.gz, .bw".format(target)
         )
     double_sex_chrom_counts(output)
-    
+
 
 def double_sex_chrom_counts(output):
-    # Double the count values for X chromosomes to make it seem like it has
-    # 2 copies
-    awk_command = r'''awk 'BEGIN {FS=OFS="\t"} substr($1, length($1)) == "X" { $4 *= 2 } 1' '''
+    # Double the count values for sex chromosomes to make it seem
+    # like they have 2 copies
+    awk_command = r"""awk 'BEGIN {FS=OFS="\t"} (substr($1, length($1)) == "X" || substr($1, length($1)) == "Y") { $4 *= 2 } 1' """
     file_creation_command = f"{output} > {output}.tmp && mv {output}.tmp {output}"
     p = check_call(awk_command + file_creation_command, shell=True)
     if p != 0:
         print(p.stderr)
+
 
 def count_bam(
     bamfile, bed_file, output, genome_sizes, use_fast_count=True, verbose=True


### PR DESCRIPTION
Double the activity for X and Y chromosomes. We have to make sure we do this early, as downstream steps do selection based on activity (e.g selecting top 150k peaks). We take extra care to ensure activity from H3K27ac is also doubled.

## Test Plan
https://pastebin.com/bkS22gv9

Verified that activity was doubled in counts bed file for DHS and H3K27ac. Note that looking at final ABC numerator score isn't doubled for X/Y chromosomes due to quantile normalization.

