### PR TITLE
fix predictor output columns

### DIFF
--- a/workflow/scripts/predict.py
+++ b/workflow/scripts/predict.py
@@ -190,23 +190,18 @@ def main():
     print("reading enhancers")
     enhancers_full = pd.read_csv(args.enhancers, sep="\t")
     enhancers_column_names = ["chr", "start", "end", "name", "class", "activity_base"]
-    try:
-        ["ATAC", "DHS"].index(args.accessibility_feature)
-    except ValueError:
-        print("The feature has to be either ATAC or DHS!")
-    else:
-        if args.accessibility_feature == "ATAC":
-            subset_columns = genes_columns_to_subset + ["ATAC.RPKM.quantile.TSS1Kb"]
-            genes = genes.loc[:, subset_columns]
-            genes.columns = genes_column_names + ["normalized_atac"]
-            subset_columns = enhancers_column_names + ["normalized_atac"]
-            enhancers = enhancers_full.loc[:, subset_columns]
-        elif args.accessibility_feature == "DHS":
-            subset_columns = genes_columns_to_subset + ["DHS.RPKM.quantile.TSS1Kb"]
-            genes = genes.loc[:, subset_columns]
-            genes.columns = genes_column_names + ["normalized_dhs"]
-            subset_columns = enhancers_column_names + ["normalized_dhs"]
-            enhancers = enhancers_full.loc[:, subset_columns]
+    if args.accessibility_feature not in {"ATAC", "DHS"}:
+        raise ValueError("The feature has to be either ATAC or DHS!")
+
+    genes_subset_columns = genes_columns_to_subset
+    genes = genes.loc[:, genes_subset_columns]
+    genes.columns = genes_column_names
+
+    normalized_activity_cols = [
+        col for col in enhancers_full.columns if col.startswith("normalized_")
+    ]
+    enh_subset_columns = enhancers_column_names + normalized_activity_cols
+    enhancers = enhancers_full.loc[:, enh_subset_columns]
 
     enhancers["activity_base_squared"] = enhancers["activity_base"] ** 2
     # Initialize Prediction files


### PR DESCRIPTION
Reintroduce 'normalized_h3k27ac' column, which was removed in [ATAC compatibility PR](https://github.com/broadinstitute/ABC-Enhancer-Gene-Prediction/pull/122)

Remove the weird `normalized_dhs_b` or `normalized_atac_b` column you would see in final prediction file.

## Test Plan
New column names
```
(base) [atan5133@sh03-ln05 login /oak/stanford/groups/engreitz/Users/atan5133/ABC-Enhancer-Gene-Prediction/results/K562_chr22/Predictions]$ zcat EnhancerPredictionsAllPutative.tsv.gz | head -1
chr     start   end     name    class   activity_base   normalized_h3K27ac      normalized_dhs  activity_base_squared   TargetGene      TargetGeneTSS   TargetGeneExpression        TargetGenePromoterActivityQuantile      TargetGeneIsExpressed   TargetGeneEnsembl_ID    distance        isSelfPromoter  powerlaw_contact        powerlaw_contact_reference  hic_contact     juicebox_contact_values hic_contact_pl_scaled   hic_pseudocount hic_contact_pl_scaled_adj       ABC.Score.Numerator     ABC.Score   powerlaw.Score.Numerator        powerlaw.Score  CellType        hic_contact_squared
```

Before
```
(base) [atan5133@sh03-ln05 login /oak/stanford/groups/engreitz/Users/atan5133/ABC-Enhancer-Gene-Prediction/results/K562_chr22/Predictions]$ zcat ../../../../abc_run_comparisons/results_no_qnorm_08_28_dev/Predictions/EnhancerPredictionsAllPutative.tsv.gz | head -1
chr     start   end     name    class   activity_base   normalized_dhs  activity_base_squared   TargetGene      TargetGeneTSS   TargetGeneExpression    TargetGenePromoterActivityQuantile  TargetGeneIsExpressed   TargetGeneEnsembl_ID    normalized_dhs_b        distance        isSelfPromoter  powerlaw_contact        powerlaw_contact_reference  hic_contact     juicebox_contact_values hic_contact_pl_scaled   hic_pseudocount hic_contact_pl_scaled_adj       ABC.Score.Numerator     ABC.Score  powerlaw.Score.Numerator powerlaw.Score  CellType        hic_contact_squared
```
