### PR TITLE
Support multiple accessibility and activity files

### DIFF
--- a/docs/usage/getting_started.rst
+++ b/docs/usage/getting_started.rst
@@ -87,10 +87,13 @@ biosamples config is a tsv separated file with the following columns
 	- Name to associate with your sample. e.g K562
 #. DHS
 	- DNAse-seq BAM file (sorted w/ .bai index file existence)
+	- Can pass in multiple files separated by ','
 #. ATAC
 	- ATAC-seq TagAlign file (sorted w/ Tabix .tbi index file existence)
+	- Can pass in multiple files separated by ','
 #. H3K27ac
 	- H3K27ac ChIP seq BAM file (sorted w/ .bai index file existence)
+	- Can pass in multiple files separated by ','
 #. default_accessibility_feature
 	- Choices: "DHS", "ATAC" (If you provided DHS BAM file, you would put "DHS" here)
 #. HiC_file

--- a/workflow/rules/candidate_regions.smk
+++ b/workflow/rules/candidate_regions.smk
@@ -1,7 +1,7 @@
 rule make_candidate_regions:
 	input:
 		narrowPeak = os.path.join(RESULTS_DIR, "{biosample}", "Peaks", "macs2_peaks.narrowPeak.sorted"),
-		accessibility = get_accessibility_file,
+		accessibility = get_accessibility_files,
 		chrom_sizes_bed = os.path.join(RESULTS_DIR, "tmp", config['ref']['chrom_sizes'] + '.bed'),
 	params:
 		TSS = lambda wildcards: BIOSAMPLES_CONFIG.loc[wildcards.biosample, 'TSS'],
@@ -21,7 +21,7 @@ rule make_candidate_regions:
 		"""
 		python {params.scripts_dir}/makeCandidateRegions.py \
 			--narrowPeak {input.narrowPeak}\
-			--bam {input.accessibility} \
+			--accessibility {input.accessibility} \
 			--outDir {params.output_dir} \
 			--chrom_sizes {params.chrom_sizes} \
 			--chrom_sizes_bed {input.chrom_sizes_bed} \

--- a/workflow/rules/macs2.smk
+++ b/workflow/rules/macs2.smk
@@ -1,7 +1,8 @@
 ## call macs2 -- if multiple accessibility inputs for one biosample, will aggregate into one output
 rule call_macs_peaks: 
 	input:
-		accessibility = get_accessibility_file
+		accessibility = get_accessibility_files,
+		test = "workflow/scripts/predict.py"
 	params:
 		pval = config['params_macs']['pval'],
 		genome_size = config['params_macs']['genome_size'],
@@ -14,7 +15,7 @@ rule call_macs_peaks:
 		mem_mb=determine_mem_mb
 	shell: 
 		"""
-		if [[ {input.accessibility} == *tagAlign* ]]; then
+		if [[ "{input.accessibility}" == *tagAlign* ]]; then
 			FORMAT="BED"
 		else
 			FORMAT="AUTO"

--- a/workflow/rules/predictions.smk
+++ b/workflow/rules/predictions.smk
@@ -28,7 +28,7 @@ rule create_predictions:
 		allPutative = os.path.join(RESULTS_DIR, "{biosample}", "Predictions", "EnhancerPredictionsAllPutative.tsv.gz"),
 		allPutativeNonExpressed = os.path.join(RESULTS_DIR, "{biosample}", "Predictions", "EnhancerPredictionsAllPutativeNonExpressedGenes.tsv.gz"),
 	resources:
-		mem_mb=64*1000
+		mem_mb=32*1000
 	shell:
 		"""
 		python {params.scripts_dir}/predict.py \

--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -13,9 +13,8 @@ MAX_MEM_MB = 250 * 1000  # 250GB
 def determine_mem_mb(wildcards, input, attempt, min_gb=8):
 	# Memory resource calculator for snakemake rules
 	input_size_mb = input.size_mb
-	for _, file in input.items():
-		if file.endswith('gz'):
-			input_size_mb *= 5  # assume gz compressesed the file <= 5x
+	if ".gz" in str(input):
+		input_size_mb *= 5  # assume gz compressesed the file <= 5x
 	attempt_multiplier = 2 ** (attempt - 1)  # Double memory for each retry
 	mem_to_use_mb = attempt_multiplier *  max(4 * input_size_mb, min_gb * 1000)
 	return min(mem_to_use_mb, MAX_MEM_MB)
@@ -54,9 +53,10 @@ def load_biosamples_config(config):
 	_configure_tss_and_gene_files(biosamples_config)
 	return biosamples_config
 
-def get_accessibility_file(wildcards):
+def get_accessibility_files(wildcards):
 	# Inputs have been validated so only DHS or ATAC is provided
-	return BIOSAMPLES_CONFIG.loc[wildcards.biosample, "DHS"] or BIOSAMPLES_CONFIG.loc[wildcards.biosample, "ATAC"]
+	files = BIOSAMPLES_CONFIG.loc[wildcards.biosample, "DHS"] or BIOSAMPLES_CONFIG.loc[wildcards.biosample, "ATAC"]
+	return files.split(",")
 
 
 def _validate_accessibility_feature(row: pd.Series):

--- a/workflow/scripts/makeCandidateRegions.py
+++ b/workflow/scripts/makeCandidateRegions.py
@@ -25,10 +25,10 @@ def parseargs(required_args=True):
         help="narrowPeak file output by macs2. Must include summits (--call-summits)",
     )
     parser.add_argument(
-        "--bam",
+        "--accessibility",
         required=required_args,
-        nargs="?",
-        help="DNAase-Seq or ATAC-Seq bam/tagalign file",
+        nargs="+",
+        help="List of DNAase-Seq or ATAC-Seq bam/tagalign files",
     )
     parser.add_argument(
         "--chrom_sizes",
@@ -86,7 +86,7 @@ def processCellType(args):
     if not args.ignoreSummits:
         make_candidate_regions_from_summits(
             macs_peaks=args.narrowPeak,
-            accessibility_file=args.bam,
+            accessibility_files=args.accessibility,
             genome_sizes=args.chrom_sizes,
             genome_sizes_bed=args.chrom_sizes_bed,
             regions_includelist=args.regions_includelist,
@@ -98,7 +98,7 @@ def processCellType(args):
     else:
         make_candidate_regions_from_peaks(
             macs_peaks=args.narrowPeak,
-            accessibility_file=args.bam,
+            accessibility_files=args.accessibility,
             genome_sizes=args.chrom_sizes,
             genome_sizes_bed=args.chrom_sizes_bed,
             regions_includelist=args.regions_includelist,


### PR DESCRIPTION
Support passing in multiple accessibility files (DHS, ATAC, H3K27ac).

Behavior when passing multiple files is that the reads at a particular enhancer will be the average of the input files.

Also refactored to clean up the shared code and rename things better.

Update docs tor reflect changes

## Test Plan

<img width="729" alt="image" src="https://github.com/broadinstitute/ABC-Enhancer-Gene-Prediction/assets/10254642/032a412a-2ca3-46f8-bc58-15eabd390854">


[config](https://pastebin.com/xEqLeLda)