### PR TITLE
Fix extract avg hic

### DIFF
--- a/workflow/scripts/extract_avg_hic.py
+++ b/workflow/scripts/extract_avg_hic.py
@@ -1,7 +1,8 @@
-import click
 import gzip
 import os
 import subprocess
+
+import click
 
 
 @click.command()
@@ -16,6 +17,7 @@ def main(avg_hic_bed_file, output_dir):
             if line.startswith("#"):  # header line
                 continue
             chrom = line.split("\t")[0]
+            hic_info = "\t".join(line.split("\t")[1:])
 
             if chrom not in file_handles:
                 print(f"Writing lines for {chrom}")
@@ -24,7 +26,7 @@ def main(avg_hic_bed_file, output_dir):
                     os.path.join(output_dir, chrom), f"{chrom}.bed"
                 )
                 file_handles[chrom] = open(chrom_file, "w")
-            file_handles[chrom].write(line)
+            file_handles[chrom].write(hic_info)
 
     # Close all file handles
     for fh in file_handles.values():


### PR DESCRIPTION
We don't want to write the chromosome as the first column as it causes issues when making predictions

Before
```
(base) [atan5133@sh02-ln01 login /oak/stanford/groups/engreitz/Users/atan5133/data/AvgHiC/chr1]$ zcat chr1.bed.gz | head
chr1    5000    186795000       0.0280977284203789
chr1    10000   2240000 0.0065670629709715
chr1    10000   6690000 0.0058807434006601
```

After
```
(base) [atan5133@sh02-ln01 login /oak/stanford/groups/engreitz/Users/atan5133/data/AvgHiC/chr1]$ zcat chr1.bed.gz | head
5000    186795000       0.0280977284203789
10000   2240000 0.0065670629709715
10000   6690000 0.0058807434006601
10000   59590000        0.005919546506088
10000   228830000       0.0034681334609455
```

## Test plan

Passed the created avg hic directory into snakemake pipeline and it works against chr22