### PR TITLE
make sure we import hicstraw before pandas

### DIFF
--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -2,11 +2,10 @@ import os
 import sys
 import unittest
 
-import pandas as pd
-
 SCRIPTS_DIR = os.path.abspath("workflow/scripts")
 sys.path.insert(0, SCRIPTS_DIR)
-from predictor import add_hic_from_hic_file, determine_num_rows_to_fetch
+from predictor import add_hic_from_hic_file
+import pandas as pd
 
 HIC_FILE = "https://www.encodeproject.org/files/ENCFF621AIY/@@download/ENCFF621AIY.hic"
 

--- a/workflow/scripts/predict.py
+++ b/workflow/scripts/predict.py
@@ -3,9 +3,9 @@ import os
 import os.path
 import time
 
+from predictor import make_predictions  # hicstraw must be imported before pandas
 import pandas as pd
 from getVariantOverlap import test_variant_overlap
-from predictor import make_predictions
 from tools import determine_expressed_genes, write_params
 
 

--- a/workflow/scripts/predictor.py
+++ b/workflow/scripts/predictor.py
@@ -3,7 +3,7 @@ import time
 from collections import defaultdict
 from typing import Dict
 
-import hicstraw
+import hicstraw  # hicstraw must be imported before pandas
 import numpy as np
 import pandas as pd
 from hic import (
@@ -257,7 +257,11 @@ def add_hic_from_hic_file(pred, hic_file, chromosome, hic_resolution):
         axis=1,
         errors="ignore",
     )
-    print("HiC added to predictions table. Elapsed time: {}".format(time.time() - start_time))
+    print(
+        "HiC added to predictions table. Elapsed time: {}".format(
+            time.time() - start_time
+        )
+    )
     return pred.rename(columns={"counts": "hic_contact"})
 
 


### PR DESCRIPTION
Error if you import pandas first

```
>>> import pandas as pd
>>> import hicstraw
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: /oak/stanford/groups/engreitz/Users/atan5133/ENCODE_rE2G/.snakemake/conda/d4c59668640d19bc431ea0a5ec74ff0e_/lib/python3.10/site-packages/pyarrow/../../../libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by /oak/stanford/groups/engreitz/Users/atan5133/ENCODE_rE2G/.snakemake/conda/d4c59668640d19bc431ea0a5ec74ff0e_/lib/python3.10/site-packages/hicstraw.cpython-310-x86_64-linux-gnu.so)

```

This error started happening when we include pyarrow as a conda dependency