### PR TITLE
Change some prediction column names of ABC

### DIFF
--- a/tests/test_full_abc_run.py
+++ b/tests/test_full_abc_run.py
@@ -1,3 +1,4 @@
+import glob
 import logging
 import os
 import time
@@ -6,7 +7,6 @@ from typing import Dict
 
 import numpy as np
 import pandas as pd
-import glob
 import yaml
 from utils import get_biosample_names, get_filtered_dataframe, read_file, run_cmd
 

--- a/workflow/scripts/predictor.py
+++ b/workflow/scripts/predictor.py
@@ -51,21 +51,21 @@ def make_predictions(
 
         pred = compute_score(
             pred,
-            [pred["activity_base"], pred["hic_contact_pl_scaled_adj"]],
+            [pred["activity_base_enh"], pred["hic_contact_pl_scaled_adj"]],
             "ABC",
             adjust_self_promoters=True,
         )
     else:
         pred = compute_score(
             pred,
-            [pred["activity_base"], pred["powerlaw_contact"]],
+            [pred["activity_base_enh"], pred["powerlaw_contact"]],
             "ABC",
             adjust_self_promoters=True,
         )
 
     pred = compute_score(
         pred,
-        [pred["activity_base"], pred["powerlaw_contact"]],
+        [pred["activity_base_enh"], pred["powerlaw_contact"]],
         "powerlaw",
         adjust_self_promoters=True,
     )
@@ -87,7 +87,6 @@ def make_pred_table(chromosome, enh, genes, window, chrom_sizes_map: Dict[str, i
         end_slop=window,
         chrom_sizes_map=chrom_sizes_map,
     )
-
     pred = enh_pr.join(genes_pr).df.drop(
         ["Start_b", "End_b", "chr_b", "Chromosome", "Start", "End"], axis=1
     )


### PR DESCRIPTION
Change the column names to make things more clear for downstream applications

See column renaming here
```
![image](https://github.com/broadinstitute/ABC-Enhancer-Gene-Prediction/assets/10254642/dd10f0d2-2b95-4f94-934b-da2578f827cc)
```

## Test Plan
Ran chr22 w/ DHS + H3k27ac
```
(abc-env) [atan5133@sh03-ln05 login /oak/stanford/groups/engreitz/Users/atan5133/ABC-Enhancer-Gene-Prediction]$ zcat results/K562_chr22/Predictions/EnhancerPredictionsAllPutative.tsv.gz | head -1
chr     start   end     name    class   activity_base   activity_base_enh       activity_base_squared_enh       normalized_dhs_enh      normalized_h3k27ac_enh      TargetGene      TargetGeneTSS   TargetGeneExpression    TargetGenePromoterActivityQuantile      TargetGeneIsExpressed   TargetGeneEnsembl_ID    normalized_dhs_prom normalized_h3k27ac_prom distance        isSelfPromoter  powerlaw_contact        powerlaw_contact_reference      hic_contact     hic_contact_pl_scaled       hic_pseudocount hic_contact_pl_scaled_adj       ABC.Score.Numerator     ABC.Score       powerlaw.Score.Numerator        powerlaw.Score  CellType    hic_contact_squared
```

Ran chr22 w/ DHS only
Note that there's no h3k27ac columns
```
(abc-env) [atan5133@sh03-ln05 login /oak/stanford/groups/engreitz/Users/atan5133/ABC-Enhancer-Gene-Prediction]$ zcat results/K562_chr22/Predictions/EnhancerPredictionsAllPutative.tsv.gz | head -1
chr     start   end     name    class   activity_base   activity_base_enh       activity_base_squared_enh       normalized_dhs_enh      TargetGene      TargetGeneTSS       TargetGeneExpression    TargetGenePromoterActivityQuantile      TargetGeneIsExpressed   TargetGeneEnsembl_ID    normalized_dhs_prom     distance    isSelfPromoter  powerlaw_contact        powerlaw_contact_reference      hic_contact     hic_contact_pl_scaled   hic_pseudocount hic_contact_pl_scaled_adj   ABC.Score.Numerator     ABC.Score       powerlaw.Score.Numerator        powerlaw.Score  CellType        hic_contact_squared
```

Full ABC genomewide CRISPR Benchmark:
For good measure, i tested different combos (DHS only, ATAC + H3K27ac) against the reference predictions that we've made before. Results are exactly the same.

![image](https://github.com/broadinstitute/ABC-Enhancer-Gene-Prediction/assets/10254642/2e85de9d-0051-409d-9706-5066c7dac659)

