### PR TITLE
use distributed pytest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            conda run -n abc-env pytest
+            conda run -n abc-env pytest -n 4
       - slack/notify:
           branch_pattern: dev,main 
           channel: abc_circleci

--- a/workflow/envs/abcenv.yml
+++ b/workflow/envs/abcenv.yml
@@ -17,6 +17,7 @@ dependencies:
   - pyarrow
   - pyranges
   - pysam
+  - pytest-xdist
   - python>=3.6
   - samtools>=1.9  # to avoid open ssl issue: https://github.com/merenlab/anvio/issues/1479
   - scipy


### PR DESCRIPTION
This allows us to run multiple tests in parallel on CircleCI. CircleCI only has 2 cores, but we specify using 4, since many of our processes can be I/O bound