### PR TITLE
enforce upper bound on cryptography package

### DIFF
--- a/workflow/envs/abcenv.yml
+++ b/workflow/envs/abcenv.yml
@@ -8,6 +8,7 @@ dependencies:
   - bedtools=2.26.0
   - black
   - click
+  - cryptography<42
   - macs2
   - matplotlib
   - numpy


### PR DESCRIPTION
Ensure cryptography package version is < 42 in order to be compatible with the pyopenssl version installed with samtools: see here for explanation https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/918

Tested by running CircleCI tests with new environment, and all passed.