### PR TITLE
Move activity to input

### DIFF
--- a/workflow/rules/neighborhoods.smk
+++ b/workflow/rules/neighborhoods.smk
@@ -1,7 +1,8 @@
 rule create_neighborhoods:
 	input:		
 		candidateRegions = os.path.join(RESULTS_DIR, "{biosample}", "Peaks", "macs2_peaks.narrowPeak.sorted.candidateRegions.bed"),
-		chrom_sizes_bed = os.path.join(RESULTS_DIR, "tmp", os.path.basename(config['ref']['chrom_sizes']) + '.bed')
+		chrom_sizes_bed = os.path.join(RESULTS_DIR, "tmp", os.path.basename(config['ref']['chrom_sizes']) + '.bed'),
+		activity_files = get_activity_files
 	params:
 		DHS = lambda wildcards: BIOSAMPLES_CONFIG.loc[wildcards.biosample, "DHS"] or '',
 		ATAC = lambda wildcards: BIOSAMPLES_CONFIG.loc[wildcards.biosample, "ATAC"] or '',

--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -124,6 +124,14 @@ def get_accessibility_files(wildcards):
 	files = BIOSAMPLES_CONFIG.loc[wildcards.biosample, "DHS"] or BIOSAMPLES_CONFIG.loc[wildcards.biosample, "ATAC"]
 	return files.split(",")
 
+def get_activity_files(wildcards):
+	# for neighborhoods step, to trigger download of necessary inputs
+	files = get_accessibility_files(wildcards)
+	k27ac_value = BIOSAMPLES_CONFIG.loc[wildcards.biosample, "H3K27ac"]
+	if k27ac_value:
+		k27ac_files = k27ac_value.split(",")
+		files = files + k27ac_files
+	return files
 
 def _validate_accessibility_feature(row: pd.Series):
 	if row["DHS"] and row["ATAC"]:


### PR DESCRIPTION
Add function to determine list of input activity files so that make_candidate_regions can take them as input (and validate existence of potential H3K27ac inputs).