### PR TITLE
update replace() usage to address deprecation FutureWarning

### DIFF
--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -106,8 +106,8 @@ def load_biosamples_config(config):
 	biosamples_config = enable_retry(
 		pd.read_csv, 
 		func_args={'filepath_or_buffer': config["biosamplesTable"], 'sep': "\t"}
-	).replace([np.nan], [None]).set_index("biosample", drop=False)
-	biosamples_config["HiC_resolution"] = biosamples_config["HiC_resolution"].replace([None], [0]).astype(int)
+	).replace([np.nan], [None]).infer_objects(copy=False).set_index("biosample", drop=False)
+	biosamples_config["HiC_resolution"] = biosamples_config["HiC_resolution"].fillna(0).astype(int)
 	_validate_biosamples_config(biosamples_config)
 	_configure_tss_and_gene_files(biosamples_config)
 	return biosamples_config


### PR DESCRIPTION
Users often get the warning 
ABC/workflow/rules/utils.smk:112: FutureWarning: Downcasting behavior in `replace` is deprecated and will be removed in a
 future version. To retain the old behavior, explicitly call `result.infer_objects(copy=False)`. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`

The warning is about replace() silently downcasting dtypes (e.g., float64 to int64) after substitution. This behavior is deprecated.

Line 109 — Keep the .replace() but chain
 .infer_objects(copy=False) to silence the warning and opt into the new behavior:

 ...).replace([np.nan], [None]).infer_objects(copy=False).set_index("biosample", drop=False)

 Line 110 — Replace .replace([None], [0]) with .fillna(0), which is the idiomatic way to substitute missing/None values and doesn't trigger the downcasting warning:

 biosamples_config["HiC_resolution"] = biosamples_config["HiC_resolution"].fillna(0).astype(int)

